### PR TITLE
Mrtrix3 descriptors

### DIFF
--- a/code/tractography/mrtrix/Dockerfile
+++ b/code/tractography/mrtrix/Dockerfile
@@ -1,0 +1,17 @@
+FROM centos:7
+RUN yum update \
+    && yum install git centos-release-scl zlib-devel gsl-devel qt5-qt3d-devel qt5-qtsvg-devel bzip2 -y
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
+RUN yum install devtoolset-7 -y
+RUN mkdir -p /src/eigen3 \
+    && curl -fsSL http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2 \
+    | tar -xjC /src/eigen3 --strip-components 1
+ENV ARCH='x86-64'
+ENV PATH=$PATH:/usr/lib64/qt5/bin
+ENV PATH=/opt/rh/devtoolset-7/root/usr/bin/:$PATH
+ENV EIGEN_CFLAGS="-isystem /src/eigen3"
+RUN git clone https://github.com/MRtrix3/mrtrix3.git /src/mrtrix3/ \
+    && cd /src/mrtrix3 \
+    && ./configure \
+    && NUMBER_OF_PROCESSORS=1 ./build
+ENV PATH=$PATH:/src/mrtrix3/bin

--- a/code/tractography/mrtrix/Dockerfile
+++ b/code/tractography/mrtrix/Dockerfile
@@ -1,0 +1,17 @@
+FROM centos:latest
+RUN yum update \
+    && yum install git centos-release-scl zlib-devel gsl-devel qt5-qt3d-devel qt5-qtsvg-devel bzip2 -y
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
+RUN yum install devtoolset-7 -y
+RUN mkdir -p /src/eigen3 \
+    && curl -fsSL http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2 \
+    | tar -xjC /src/eigen3 --strip-components 1
+ENV ARCH='x86-64'
+ENV PATH=$PATH:/usr/lib64/qt5/bin
+ENV PATH=/opt/rh/devtoolset-7/root/usr/bin/:$PATH
+ENV EIGEN_CFLAGS="-isystem /src/eigen3"
+RUN git clone https://github.com/MRtrix3/mrtrix3.git
+RUN cd mrtrix3 \
+    && ./configure \
+    && NUMBER_OF_PROCESSORS=1 ./build
+ENV PATH=$PATH:/mrtrix3/bin

--- a/code/tractography/mrtrix/Dockerfile
+++ b/code/tractography/mrtrix/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM centos:7
 RUN yum update \
     && yum install git centos-release-scl zlib-devel gsl-devel qt5-qt3d-devel qt5-qtsvg-devel bzip2 -y
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
@@ -10,8 +10,8 @@ ENV ARCH='x86-64'
 ENV PATH=$PATH:/usr/lib64/qt5/bin
 ENV PATH=/opt/rh/devtoolset-7/root/usr/bin/:$PATH
 ENV EIGEN_CFLAGS="-isystem /src/eigen3"
-RUN git clone https://github.com/MRtrix3/mrtrix3.git
-RUN cd mrtrix3 \
+RUN git clone https://github.com/MRtrix3/mrtrix3.git /src/mrtrix3/ \
+    && cd /src/mrtrix3 \
     && ./configure \
     && NUMBER_OF_PROCESSORS=1 ./build
-ENV PATH=$PATH:/mrtrix3/bin
+ENV PATH=$PATH:/src/mrtrix3/bin

--- a/code/tractography/mrtrix/dwi2fod_desc.json
+++ b/code/tractography/mrtrix/dwi2fod_desc.json
@@ -1,6 +1,6 @@
 {
     "author": "Darrin Fong",
-    "command-line": "dwi2fod [GRAD] [FSLGRAD] [BVECS] [BVALS] [BVALUE_SCALING] [SHELL] [DIRECTIONS] [LMAX] [MASK] [FILTER] [NEG_LAMBDA] [NORM_LAMBDA] [THRESHOLD] [NITER] [STRIDE] [INFO] [QUIET] [DEBUG] [FORCE] [NTHREADS] [FAILONWARN] [HELP] [VERSION] [ALGORITHM] [DWI] [RESPONSE] [ODF]",
+    "command-line": "dwi2fod [GRAD] [FSLGRAD] [BVECS] [BVALS] [BVALUE_SCALING] [SHELL] [DIRECTIONS] [LMAX] [MASK] [FILTER] [NEG_LAMBDA] [NORM_LAMBDA] [THRESHOLD] [NITER] [STRIDE] [INFO] [QUIET] [DEBUG] [FORCE] [NTHREADS] [HELP] [VERSION] [ALGORITHM] [DWI] [RESPONSE] [ODF]",
     "container-image": {
         "image": "darrinfong/mrtrix3:latest",
         "index": "index.docker.io",
@@ -241,7 +241,7 @@
         {
             "description": "A text file containing the diffusion-weighted signal response function coefficients for a single fibre population",
             "id": "response",
-            "name": "response output",
+            "name": "input tissue response",
             "optional": false,
             "type": "File",
             "value-key": "[RESPONSE]"
@@ -251,25 +251,16 @@
             "id": "odf",
             "name": "odf images",
             "optional": false,
-            "type": "File",
+            "type": "String",
             "value-key": "[ODF]"
         }
     ],
     "output-files": [
         {
-            "id": "response_output",
-            "name": "response output",
-            "optional": false,
-            "path-template": "[RESPONSE].txt",
-            "path-template-stripped-extensions": [
-                ".txt"
-            ]
-        },
-        {
             "id": "odf_output",
             "name": "Spherical harmonics coefficients image output",
             "optional": true,
-            "path-template": "[ODF].nii",
+            "path-template": "[ODF].nii.gz",
             "path-template-stripped-extensions": [
                 ".nii.gz",
                 ".nii"

--- a/code/tractography/mrtrix/dwi2fod_desc.json
+++ b/code/tractography/mrtrix/dwi2fod_desc.json
@@ -1,0 +1,295 @@
+{
+    "author": "Darrin Fong",
+    "command-line": "dwi2fod [GRAD] [FSLGRAD] [BVECS] [BVALS] [BVALUE_SCALING] [SHELL] [DIRECTIONS] [LMAX] [MASK] [FILTER] [NEG_LAMBDA] [NORM_LAMBDA] [THRESHOLD] [NITER] [STRIDE] [INFO] [QUIET] [DEBUG] [FORCE] [NTHREADS] [FAILONWARN] [HELP] [VERSION] [ALGORITHM] [DWI] [RESPONSE] [ODF]",
+    "container-image": {
+        "image": "darrinfong/mrtrix3:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "name": "dwi2fod Spherical deconvolution",
+    "description": "Estimate fibre orientation distributions from diffusion data using spherical deconvolution.",
+    "inputs": [
+        {
+            "command-line-flag": "-grad",
+            "description": "Provide the diffusion-weighted gradient scheme used in the acquisition in a text file. This should be supplied as a 4xN text file with each line is in the format [ X Y Z b ], where [ X Y Z ] describe the direction of the applied gradient, and b gives the b-value in units of s/mm^2. If a diffusion gradient scheme is present in the input image header, the data provided with this option will be instead used.",
+            "id": "grad",
+            "name": "grad",
+            "optional": true,
+            "type": "File",
+            "value-key": "[GRAD]"
+        },
+        {
+            "command-line-flag": "-fslgrad",
+            "description": "Provide the diffusion-weighted gradient scheme used in the acquisition in FSL bvecs/bvals format files. If a diffusion gradient scheme is present in the input image header, the data provided with this option will be instead used.",
+            "id": "fslgrad",
+            "name": "fslgrad",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FSLGRAD]",
+            "requires-inputs": ["bvecs", "bvals"]
+        },
+        {
+            "description": "Specify the diffusion-weighted gradient scheme used in the acquisition in FSL bvecs format.",
+            "id": "bvecs",
+            "name": "bvecs",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVECS]",
+            "requires-inputs": ["fslgrad", "bvals"]
+        },
+        {
+            "description": "Specify the diffusion-weighted gradient scheme used in the acquisition in FSL bvals format.",
+            "id": "bvals",
+            "name": "bvals",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVALS]",
+            "requires-inputs": ["fslgrad", "bvecs"]
+        },
+        {
+            "command-line-flag": "-bvalue_scaling",
+            "description": "Specifies whether the b-values should be scaled by the square of the corresponding DW gradient norm, as often required for multi-shell or DSI DW acquisition schemes. The default action can also be set in the MRtrix config file, under the BValueScaling entry. Valid choices are yes/no, true/false, 0/1 (default: true).",
+            "id": "bvalue_scaling",
+            "name": "bvalue_scaling",
+            "optional": true,
+            "type": "String",
+            "value-key": "[BVALUE_SCALING]",
+            "value-choices": ["yes", "no", "true", "false", "0", "1"],
+            "default-value": "true"
+        },
+        {
+            "command-line-flag": "-shell",
+            "description": "Specify one or more b-values to use during processing, as a comma-separated list of the desired approximate b-values (b-values are clustered to allow for small deviations). Note that some commands are incompatible with multiple b-values, and will report an error if more than one b-value is provided. \nWARNING: note that, even though the b=0 volumes are never referred to as shells in the literature, they still have to be explicitly included in the list of b-values as provided to the -shell option! Several algorithms which include the b=0 volumes in their computations may otherwise return an undesired result.",
+            "id": "shell",
+            "name": "Diffusion-weighted gradient shell(s)",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "value-key": "[SHELL]"
+        },
+        {
+            "command-line-flag": "-directions",
+            "description": "Specify the directions over which to apply the non-negativity constraint (by default, the built-in 300 direction set is used). These should be supplied as a text file containing the [ az el ] pairs for the directions.",
+            "id": "directions",
+            "name": "directions",
+            "optional": true,
+            "type": "File",
+            "value-key": "[DIRECTIONS]"
+        },
+        {
+            "command-line-flag": "-lmax",
+            "description": "The maximum spherical harmonic order for the output FOD(s).For algorithms with multiple outputs, this should be provided as a comma-separated list of integers, one for each output image; for single-output algorithms, only a single integer should be provided. If omitted, the command will use the highest possible lmax given the diffusion gradient table, up to a maximum of 8.",
+            "id": "lmax",
+            "name": "Maximum harmonic order",
+            "optional": true,
+            "type": "Number",
+            "maximum": 8,
+            "value-key": "[LMAX]"
+        },
+        {
+            "command-line-flag": "-mask",
+            "description": "Only perform computation within the specified binary brain mask image.",
+            "id": "mask",
+            "name": "mask",
+            "optional": true,
+            "type": "File",
+            "value-key": "[MASK]"
+        },
+        {
+            "command-line-flag": "-filter",
+            "description": "The linear frequency filtering parameters used for the initial linear spherical deconvolution step (default = [ 1 1 1 0 0 ]). These should be supplied as a text file containing the filtering coefficients for each even harmonic order.",
+            "id": "filter",
+            "name": "filter",
+            "optional": true,
+            "type": "File",
+            "value-key": "[FILTER]"
+        },
+        {
+            "command-line-flag": "-neg_lambda",
+            "description": "The regularisation parameter lambda that controls the strength of the non-negativity constraint (default = 1.0).",
+            "id": "neg_lambda",
+            "name": "neg_lambda",
+            "optional": true,
+            "default-value": 1.0,
+            "type": "Number",
+            "value-key": "[NEG_LAMBDA]"
+        },
+        {
+            "command-line-flag": "-norm_lambda",
+            "description": "The regularisation parameter lambda that controls the strength of the constraint on the norm of the solution (default = 1.0).",
+            "id": "norm_lambda",
+            "name": "norm_lambda",
+            "optional": true,
+            "default-value": 1.0,
+            "type": "Number",
+            "value-key": "[NORM_LAMBDA]"
+        },
+        {
+            "command-line-flag": "-threshold",
+            "description": "The threshold below which the amplitude of the FOD is assumed to be zero, expressed as an absolute amplitude (default = 0.0).",
+            "id": "threshold",
+            "name": "Amplitude threshold",
+            "optional": true,
+            "default-value": 0.0,
+            "type": "Number",
+            "value-key": "[THRESHOLD]"
+        },
+        {
+            "command-line-flag": "-niter",
+            "description": "The maximum number of iterations to perform for each voxel (default = 50). Use '-niter 0' for a linear unconstrained spherical deconvolution.",
+            "id": "niter",
+            "name": "niter",
+            "optional": true,
+            "integer": true,
+            "default-value": 50,
+            "type": "Number",
+            "value-key": "[NITER]"
+        },
+        {
+            "command-line-flag": "-stride",
+            "description": "Specify the strides of the output data in memory, as a comma-separated list. The actual strides produced will depend on whether the output image format can support it.",
+            "id": "stride",
+            "name": "stride",
+            "optional": true,
+            "type": "String",
+            "value-key": "[STRIDE]"
+        },
+        {
+            "command-line-flag": "-info",
+            "description": "Display information messages.",
+            "id": "info",
+            "name": "info",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[INFO]",
+            "disables-inputs": ["quiet", "debug"]
+        },
+        {
+            "command-line-flag": "-quiet",
+            "description": "Do not display information messages or progress status.",
+            "id": "quiet",
+            "name": "quiet",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[QUIET]",
+            "disables-inputs": ["info", "debug"]
+        },
+        {
+            "command-line-flag": "-debug",
+            "description": "Display debugging messages.",
+            "id": "debug",
+            "name": "debug",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DEBUG]",
+            "disables-inputs": ["info", "quiet"]
+        },
+        {
+            "command-line-flag": "-force",
+            "description": "Force overwrite of output files. Caution: Using the same file as input and output might cause unexpected behaviour.",
+            "id": "force",
+            "name": "force",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FORCE]"
+        },
+        {
+            "command-line-flag": "-nthreads",
+            "description": "Use this number of threads in multi-threaded applications (set to 0 to disable multi-threading)",
+            "id": "nthreads",
+            "name": "nthreads",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[NTHREADS]"
+        },
+        {
+            "command-line-flag": "-help",
+            "description": "Display this information page and exit",
+            "id": "help",
+            "name": "help",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HELP]"
+        },
+        {
+            "command-line-flag": "-version",
+            "description": "Display version information and exit",
+            "id": "version",
+            "name": "version",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[VERSION]"
+        },
+        {
+            "description": "The algorithm to use for FOD estimation. (options are: csd, msmt_csd)",
+            "id": "algorithm",
+            "name": "algorithm",
+            "optional": false,
+            "type": "String",
+            "value-choices": ["csd", "msmt_csd"],
+            "value-key": "[ALGORITHM]"
+        },
+        {
+            "description": "The input diffusion-weighted images",
+            "id": "dwi",
+            "name": "dwi input",
+            "optional": false,
+            "type": "File",
+            "value-key": "[DWI]"
+        },
+        {
+            "description": "A text file containing the diffusion-weighted signal response function coefficients for a single fibre population",
+            "id": "response",
+            "name": "response output",
+            "optional": false,
+            "type": "File",
+            "value-key": "[RESPONSE]"
+        },
+        {
+            "description": "The output spherical harmonics coefficients image.",
+            "id": "odf",
+            "name": "odf images",
+            "optional": false,
+            "type": "File",
+            "value-key": "[ODF]"
+        }
+    ],
+    "output-files": [
+        {
+            "id": "response_output",
+            "name": "response output",
+            "optional": false,
+            "path-template": "[RESPONSE].txt",
+            "path-template-stripped-extensions": [
+                ".txt"
+            ]
+        },
+        {
+            "id": "odf_output",
+            "name": "Spherical harmonics coefficients image output",
+            "optional": true,
+            "path-template": "[ODF].nii",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii"
+            ]
+        }
+    ],
+    "schema-version": "0.5",
+    "suggested-resources": {
+        "cpu-cores": 1,
+        "ram": 2048,
+        "walltime-estimate": 20
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "image processing",
+            "mri",
+            "dwi",
+            "tractography"
+        ]
+    },
+    "tool-version": "v0.1.0"
+}

--- a/code/tractography/mrtrix/dwi2fod_desc.json
+++ b/code/tractography/mrtrix/dwi2fod_desc.json
@@ -1,0 +1,286 @@
+{
+    "author": "Darrin Fong",
+    "command-line": "dwi2fod [GRAD] [FSLGRAD] [BVECS] [BVALS] [BVALUE_SCALING] [SHELL] [DIRECTIONS] [LMAX] [MASK] [FILTER] [NEG_LAMBDA] [NORM_LAMBDA] [THRESHOLD] [NITER] [STRIDE] [INFO] [QUIET] [DEBUG] [FORCE] [NTHREADS] [HELP] [VERSION] [ALGORITHM] [DWI] [RESPONSE] [ODF]",
+    "container-image": {
+        "image": "darrinfong/mrtrix3:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "name": "dwi2fod Spherical deconvolution",
+    "description": "Estimate fibre orientation distributions from diffusion data using spherical deconvolution.",
+    "inputs": [
+        {
+            "command-line-flag": "-grad",
+            "description": "Provide the diffusion-weighted gradient scheme used in the acquisition in a text file. This should be supplied as a 4xN text file with each line is in the format [ X Y Z b ], where [ X Y Z ] describe the direction of the applied gradient, and b gives the b-value in units of s/mm^2. If a diffusion gradient scheme is present in the input image header, the data provided with this option will be instead used.",
+            "id": "grad",
+            "name": "grad",
+            "optional": true,
+            "type": "File",
+            "value-key": "[GRAD]"
+        },
+        {
+            "command-line-flag": "-fslgrad",
+            "description": "Provide the diffusion-weighted gradient scheme used in the acquisition in FSL bvecs/bvals format files. If a diffusion gradient scheme is present in the input image header, the data provided with this option will be instead used.",
+            "id": "fslgrad",
+            "name": "fslgrad",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FSLGRAD]",
+            "requires-inputs": ["bvecs", "bvals"]
+        },
+        {
+            "description": "Specify the diffusion-weighted gradient scheme used in the acquisition in FSL bvecs format.",
+            "id": "bvecs",
+            "name": "bvecs",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVECS]",
+            "requires-inputs": ["fslgrad", "bvals"]
+        },
+        {
+            "description": "Specify the diffusion-weighted gradient scheme used in the acquisition in FSL bvals format.",
+            "id": "bvals",
+            "name": "bvals",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVALS]",
+            "requires-inputs": ["fslgrad", "bvecs"]
+        },
+        {
+            "command-line-flag": "-bvalue_scaling",
+            "description": "Specifies whether the b-values should be scaled by the square of the corresponding DW gradient norm, as often required for multi-shell or DSI DW acquisition schemes. The default action can also be set in the MRtrix config file, under the BValueScaling entry. Valid choices are yes/no, true/false, 0/1 (default: true).",
+            "id": "bvalue_scaling",
+            "name": "bvalue_scaling",
+            "optional": true,
+            "type": "String",
+            "value-key": "[BVALUE_SCALING]",
+            "value-choices": ["yes", "no", "true", "false", "0", "1"],
+            "default-value": "true"
+        },
+        {
+            "command-line-flag": "-shell",
+            "description": "Specify one or more b-values to use during processing, as a comma-separated list of the desired approximate b-values (b-values are clustered to allow for small deviations). Note that some commands are incompatible with multiple b-values, and will report an error if more than one b-value is provided. \nWARNING: note that, even though the b=0 volumes are never referred to as shells in the literature, they still have to be explicitly included in the list of b-values as provided to the -shell option! Several algorithms which include the b=0 volumes in their computations may otherwise return an undesired result.",
+            "id": "shell",
+            "name": "Diffusion-weighted gradient shell(s)",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "value-key": "[SHELL]"
+        },
+        {
+            "command-line-flag": "-directions",
+            "description": "Specify the directions over which to apply the non-negativity constraint (by default, the built-in 300 direction set is used). These should be supplied as a text file containing the [ az el ] pairs for the directions.",
+            "id": "directions",
+            "name": "directions",
+            "optional": true,
+            "type": "File",
+            "value-key": "[DIRECTIONS]"
+        },
+        {
+            "command-line-flag": "-lmax",
+            "description": "The maximum spherical harmonic order for the output FOD(s).For algorithms with multiple outputs, this should be provided as a comma-separated list of integers, one for each output image; for single-output algorithms, only a single integer should be provided. If omitted, the command will use the highest possible lmax given the diffusion gradient table, up to a maximum of 8.",
+            "id": "lmax",
+            "name": "Maximum harmonic order",
+            "optional": true,
+            "type": "Number",
+            "maximum": 8,
+            "value-key": "[LMAX]"
+        },
+        {
+            "command-line-flag": "-mask",
+            "description": "Only perform computation within the specified binary brain mask image.",
+            "id": "mask",
+            "name": "mask",
+            "optional": true,
+            "type": "File",
+            "value-key": "[MASK]"
+        },
+        {
+            "command-line-flag": "-filter",
+            "description": "The linear frequency filtering parameters used for the initial linear spherical deconvolution step (default = [ 1 1 1 0 0 ]). These should be supplied as a text file containing the filtering coefficients for each even harmonic order.",
+            "id": "filter",
+            "name": "filter",
+            "optional": true,
+            "type": "File",
+            "value-key": "[FILTER]"
+        },
+        {
+            "command-line-flag": "-neg_lambda",
+            "description": "The regularisation parameter lambda that controls the strength of the non-negativity constraint (default = 1.0).",
+            "id": "neg_lambda",
+            "name": "neg_lambda",
+            "optional": true,
+            "default-value": 1.0,
+            "type": "Number",
+            "value-key": "[NEG_LAMBDA]"
+        },
+        {
+            "command-line-flag": "-norm_lambda",
+            "description": "The regularisation parameter lambda that controls the strength of the constraint on the norm of the solution (default = 1.0).",
+            "id": "norm_lambda",
+            "name": "norm_lambda",
+            "optional": true,
+            "default-value": 1.0,
+            "type": "Number",
+            "value-key": "[NORM_LAMBDA]"
+        },
+        {
+            "command-line-flag": "-threshold",
+            "description": "The threshold below which the amplitude of the FOD is assumed to be zero, expressed as an absolute amplitude (default = 0.0).",
+            "id": "threshold",
+            "name": "Amplitude threshold",
+            "optional": true,
+            "default-value": 0.0,
+            "type": "Number",
+            "value-key": "[THRESHOLD]"
+        },
+        {
+            "command-line-flag": "-niter",
+            "description": "The maximum number of iterations to perform for each voxel (default = 50). Use '-niter 0' for a linear unconstrained spherical deconvolution.",
+            "id": "niter",
+            "name": "niter",
+            "optional": true,
+            "integer": true,
+            "default-value": 50,
+            "type": "Number",
+            "value-key": "[NITER]"
+        },
+        {
+            "command-line-flag": "-stride",
+            "description": "Specify the strides of the output data in memory, as a comma-separated list. The actual strides produced will depend on whether the output image format can support it.",
+            "id": "stride",
+            "name": "stride",
+            "optional": true,
+            "type": "String",
+            "value-key": "[STRIDE]"
+        },
+        {
+            "command-line-flag": "-info",
+            "description": "Display information messages.",
+            "id": "info",
+            "name": "info",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[INFO]",
+            "disables-inputs": ["quiet", "debug"]
+        },
+        {
+            "command-line-flag": "-quiet",
+            "description": "Do not display information messages or progress status.",
+            "id": "quiet",
+            "name": "quiet",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[QUIET]",
+            "disables-inputs": ["info", "debug"]
+        },
+        {
+            "command-line-flag": "-debug",
+            "description": "Display debugging messages.",
+            "id": "debug",
+            "name": "debug",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DEBUG]",
+            "disables-inputs": ["info", "quiet"]
+        },
+        {
+            "command-line-flag": "-force",
+            "description": "Force overwrite of output files. Caution: Using the same file as input and output might cause unexpected behaviour.",
+            "id": "force",
+            "name": "force",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FORCE]"
+        },
+        {
+            "command-line-flag": "-nthreads",
+            "description": "Use this number of threads in multi-threaded applications (set to 0 to disable multi-threading)",
+            "id": "nthreads",
+            "name": "nthreads",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[NTHREADS]"
+        },
+        {
+            "command-line-flag": "-help",
+            "description": "Display this information page and exit",
+            "id": "help",
+            "name": "help",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HELP]"
+        },
+        {
+            "command-line-flag": "-version",
+            "description": "Display version information and exit",
+            "id": "version",
+            "name": "version",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[VERSION]"
+        },
+        {
+            "description": "The algorithm to use for FOD estimation. (options are: csd, msmt_csd)",
+            "id": "algorithm",
+            "name": "algorithm",
+            "optional": false,
+            "type": "String",
+            "value-choices": ["csd", "msmt_csd"],
+            "value-key": "[ALGORITHM]"
+        },
+        {
+            "description": "The input diffusion-weighted images",
+            "id": "dwi",
+            "name": "dwi input",
+            "optional": false,
+            "type": "File",
+            "value-key": "[DWI]"
+        },
+        {
+            "description": "A text file containing the diffusion-weighted signal response function coefficients for a single fibre population",
+            "id": "response",
+            "name": "input tissue response",
+            "optional": false,
+            "type": "File",
+            "value-key": "[RESPONSE]"
+        },
+        {
+            "description": "The output spherical harmonics coefficients image.",
+            "id": "odf",
+            "name": "odf images",
+            "optional": false,
+            "type": "String",
+            "value-key": "[ODF]"
+        }
+    ],
+    "output-files": [
+        {
+            "id": "odf_output",
+            "name": "Spherical harmonics coefficients image output",
+            "optional": true,
+            "path-template": "[ODF].nii.gz",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii"
+            ]
+        }
+    ],
+    "schema-version": "0.5",
+    "suggested-resources": {
+        "cpu-cores": 1,
+        "ram": 2048,
+        "walltime-estimate": 20
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "image processing",
+            "mri",
+            "dwi",
+            "tractography"
+        ]
+    },
+    "tool-version": "v0.1.0"
+}

--- a/code/tractography/mrtrix/dwi2fod_invoc.json
+++ b/code/tractography/mrtrix/dwi2fod_invoc.json
@@ -1,0 +1,6 @@
+{
+    "algorithm": "msmt_csd",
+    "dwi": "example_dwi.nii.gz",
+    "odf": "example_odf.nii.gz",
+    "response": "example_response.csv"
+}

--- a/code/tractography/mrtrix/dwi2fod_invoc.json
+++ b/code/tractography/mrtrix/dwi2fod_invoc.json
@@ -1,6 +1,6 @@
 {
-    "algorithm": "msmt_csd",
-    "dwi": "example_dwi.nii.gz",
-    "odf": "example_odf.nii.gz",
-    "response": "example_response.csv"
+    "algorithm": "csd",
+    "dwi": "example_dwi.mif",
+    "response": "example_response.txt",
+    "odf": "example_odf.nii.gz"
 }

--- a/code/tractography/mrtrix/dwi2mask_desc.json
+++ b/code/tractography/mrtrix/dwi2mask_desc.json
@@ -1,0 +1,184 @@
+{
+    "author": "Darrin Fong",
+    "command-line": "dwi2mask [CLEAN_SCALE] [GRAD] [FSLGRAD] [BVECS] [BVALS] [BVALUE_SCALING] [INFO] [QUIET] [DEBUG] [FORCE] [NTHREADS] [HELP] [VERSION] [INPUT] [OUTPUT]",
+    "container-image": {
+        "image": "darrinfong/mrtrix3:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "name": "dwi2mask Brain mask generator",
+    "description": "All diffusion weighted and b=0 volumes are used to obtain a mask that includes both brain tissue and CSF. \n\nIn a second step peninsula-like extensions, where the peninsula itself is wider than the bridge connecting it to the mask, are removed. This may help removing artefacts and non-brain parts, e.g. eyes, from the mask.",
+    "inputs": [
+        {
+            "command-line-flag": "-clean_scale",
+            "description": "The maximum scale used to cut bridges. A certain maximum scale cuts bridges up to a width (in voxels) of 2x the provided scale. Setting this to 0 disables the mask cleaning step. (Default: 2)",
+            "id": "clean_scale",
+            "name": "Clean scale",
+            "optional": true,
+            "type": "Number",
+            "default-value": 2,
+            "value-key": "[CLEAN_SCALE]"
+        },
+        {
+            "command-line-flag": "-grad",
+            "description": "Provide the diffusion-weighted gradient scheme used in the acquisition in a text file. This should be supplied as a 4xN text file with each line is in the format [ X Y Z b ], where [ X Y Z ] describe the direction of the applied gradient, and b gives the b-value in units of s/mm^2. If a diffusion gradient scheme is present in the input image header, the data provided with this option will be instead used.",
+            "id": "grad",
+            "name": "grad",
+            "optional": true,
+            "type": "File",
+            "value-key": "[GRAD]"
+        },
+        {
+            "command-line-flag": "-fslgrad",
+            "description": "Provide the diffusion-weighted gradient scheme used in the acquisition in FSL bvecs/bvals format files. If a diffusion gradient scheme is present in the input image header, the data provided with this option will be instead used.",
+            "id": "fslgrad",
+            "name": "fslgrad",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FSLGRAD]",
+            "requires-inputs": ["bvecs", "bvals"]
+        },
+        {
+            "description": "Specify the diffusion-weighted gradient scheme used in the acquisition in FSL bvecs format.",
+            "id": "bvecs",
+            "name": "bvecs",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVECS]",
+            "requires-inputs": ["fslgrad", "bvals"]
+        },
+        {
+            "description": "Specify the diffusion-weighted gradient scheme used in the acquisition in FSL bvals format.",
+            "id": "bvals",
+            "name": "bvals",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVALS]",
+            "requires-inputs": ["fslgrad", "bvecs"]
+        },
+        {
+            "command-line-flag": "-bvalue_scaling",
+            "description": "Specifies whether the b-values should be scaled by the square of the corresponding DW gradient norm, as often required for multi-shell or DSI DW acquisition schemes. The default action can also be set in the MRtrix config file, under the BValueScaling entry. Valid choices are yes/no, true/false, 0/1 (default: true).",
+            "id": "bvalue_scaling",
+            "name": "bvalue_scaling",
+            "optional": true,
+            "type": "String",
+            "value-key": "[BVALUE_SCALING]",
+            "value-choices": ["yes", "no", "true", "false", "0", "1"],
+            "default-value": "true"
+        },
+        {
+            "command-line-flag": "-info",
+            "description": "Display information messages.",
+            "id": "info",
+            "name": "info",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[INFO]",
+            "disables-inputs": ["quiet", "debug"]
+        },
+        {
+            "command-line-flag": "-quiet",
+            "description": "Do not display information messages or progress status.",
+            "id": "quiet",
+            "name": "quiet",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[QUIET]",
+            "disables-inputs": ["info", "debug"]
+        },
+        {
+            "command-line-flag": "-debug",
+            "description": "Display debugging messages.",
+            "id": "debug",
+            "name": "debug",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DEBUG]",
+            "disables-inputs": ["info", "quiet"]
+        },
+        {
+            "command-line-flag": "-force",
+            "description": "Force overwrite of output files. Caution: Using the same file as input and output might cause unexpected behaviour.",
+            "id": "force",
+            "name": "force",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FORCE]"
+        },
+        {
+            "command-line-flag": "-nthreads",
+            "description": "Use this number of threads in multi-threaded applications (set to 0 to disable multi-threading)",
+            "id": "nthreads",
+            "name": "nthreads",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[NTHREADS]"
+        },
+        {
+            "command-line-flag": "-help",
+            "description": "Display this information page and exit",
+            "id": "help",
+            "name": "help",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HELP]"
+        },
+        {
+            "command-line-flag": "-version",
+            "description": "Display version information and exit",
+            "id": "version",
+            "name": "version",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[VERSION]"
+        },
+        {
+            "description": "The input DWI image containing volumes that are both diffusion weighted and b=0",
+            "id": "input",
+            "name": "input",
+            "optional": false,
+            "type": "File",
+            "value-key": "[INPUT]"
+        },
+        {
+            "description": "The output whole brain mask image",
+            "id": "output_mask",
+            "name": "output_mask",
+            "optional": false,
+            "type": "String",
+            "value-key": "[OUTPUT]"
+        }
+    ],
+    "output-files": [
+        {
+            "id": "output_image",
+            "name": "Output mask image",
+            "description": "The output whole brain mask image",
+            "optional": false,
+            "path-template": "[OUTPUT].nii",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii",
+                ".json"
+            ]
+        }
+    ],
+    "schema-version": "0.5",
+    "suggested-resources": {
+        "cpu-cores": 1,
+        "ram": 2048,
+        "walltime-estimate": 20
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "image processing",
+            "mri",
+            "dwi",
+            "tractography"
+        ]
+    },
+    "tool-version": "v0.1.0"
+}

--- a/code/tractography/mrtrix/dwi2mask_desc.json
+++ b/code/tractography/mrtrix/dwi2mask_desc.json
@@ -157,11 +157,10 @@
             "name": "Output mask image",
             "description": "The output whole brain mask image",
             "optional": false,
-            "path-template": "[OUTPUT].nii",
+            "path-template": "[OUTPUT].nii.gz",
             "path-template-stripped-extensions": [
                 ".nii.gz",
-                ".nii",
-                ".json"
+                ".nii"
             ]
         }
     ],

--- a/code/tractography/mrtrix/dwi2mask_desc.json
+++ b/code/tractography/mrtrix/dwi2mask_desc.json
@@ -1,0 +1,183 @@
+{
+    "author": "Darrin Fong",
+    "command-line": "dwi2mask [CLEAN_SCALE] [GRAD] [FSLGRAD] [BVECS] [BVALS] [BVALUE_SCALING] [INFO] [QUIET] [DEBUG] [FORCE] [NTHREADS] [HELP] [VERSION] [INPUT] [OUTPUT]",
+    "container-image": {
+        "image": "darrinfong/mrtrix3:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "name": "dwi2mask Brain mask generator",
+    "description": "All diffusion weighted and b=0 volumes are used to obtain a mask that includes both brain tissue and CSF. \n\nIn a second step peninsula-like extensions, where the peninsula itself is wider than the bridge connecting it to the mask, are removed. This may help removing artefacts and non-brain parts, e.g. eyes, from the mask.",
+    "inputs": [
+        {
+            "command-line-flag": "-clean_scale",
+            "description": "The maximum scale used to cut bridges. A certain maximum scale cuts bridges up to a width (in voxels) of 2x the provided scale. Setting this to 0 disables the mask cleaning step. (Default: 2)",
+            "id": "clean_scale",
+            "name": "Clean scale",
+            "optional": true,
+            "type": "Number",
+            "default-value": 2,
+            "value-key": "[CLEAN_SCALE]"
+        },
+        {
+            "command-line-flag": "-grad",
+            "description": "Provide the diffusion-weighted gradient scheme used in the acquisition in a text file. This should be supplied as a 4xN text file with each line is in the format [ X Y Z b ], where [ X Y Z ] describe the direction of the applied gradient, and b gives the b-value in units of s/mm^2. If a diffusion gradient scheme is present in the input image header, the data provided with this option will be instead used.",
+            "id": "grad",
+            "name": "grad",
+            "optional": true,
+            "type": "File",
+            "value-key": "[GRAD]"
+        },
+        {
+            "command-line-flag": "-fslgrad",
+            "description": "Provide the diffusion-weighted gradient scheme used in the acquisition in FSL bvecs/bvals format files. If a diffusion gradient scheme is present in the input image header, the data provided with this option will be instead used.",
+            "id": "fslgrad",
+            "name": "fslgrad",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FSLGRAD]",
+            "requires-inputs": ["bvecs", "bvals"]
+        },
+        {
+            "description": "Specify the diffusion-weighted gradient scheme used in the acquisition in FSL bvecs format.",
+            "id": "bvecs",
+            "name": "bvecs",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVECS]",
+            "requires-inputs": ["fslgrad", "bvals"]
+        },
+        {
+            "description": "Specify the diffusion-weighted gradient scheme used in the acquisition in FSL bvals format.",
+            "id": "bvals",
+            "name": "bvals",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVALS]",
+            "requires-inputs": ["fslgrad", "bvecs"]
+        },
+        {
+            "command-line-flag": "-bvalue_scaling",
+            "description": "Specifies whether the b-values should be scaled by the square of the corresponding DW gradient norm, as often required for multi-shell or DSI DW acquisition schemes. The default action can also be set in the MRtrix config file, under the BValueScaling entry. Valid choices are yes/no, true/false, 0/1 (default: true).",
+            "id": "bvalue_scaling",
+            "name": "bvalue_scaling",
+            "optional": true,
+            "type": "String",
+            "value-key": "[BVALUE_SCALING]",
+            "value-choices": ["yes", "no", "true", "false", "0", "1"],
+            "default-value": "true"
+        },
+        {
+            "command-line-flag": "-info",
+            "description": "Display information messages.",
+            "id": "info",
+            "name": "info",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[INFO]",
+            "disables-inputs": ["quiet", "debug"]
+        },
+        {
+            "command-line-flag": "-quiet",
+            "description": "Do not display information messages or progress status.",
+            "id": "quiet",
+            "name": "quiet",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[QUIET]",
+            "disables-inputs": ["info", "debug"]
+        },
+        {
+            "command-line-flag": "-debug",
+            "description": "Display debugging messages.",
+            "id": "debug",
+            "name": "debug",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DEBUG]",
+            "disables-inputs": ["info", "quiet"]
+        },
+        {
+            "command-line-flag": "-force",
+            "description": "Force overwrite of output files. Caution: Using the same file as input and output might cause unexpected behaviour.",
+            "id": "force",
+            "name": "force",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FORCE]"
+        },
+        {
+            "command-line-flag": "-nthreads",
+            "description": "Use this number of threads in multi-threaded applications (set to 0 to disable multi-threading)",
+            "id": "nthreads",
+            "name": "nthreads",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[NTHREADS]"
+        },
+        {
+            "command-line-flag": "-help",
+            "description": "Display this information page and exit",
+            "id": "help",
+            "name": "help",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HELP]"
+        },
+        {
+            "command-line-flag": "-version",
+            "description": "Display version information and exit",
+            "id": "version",
+            "name": "version",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[VERSION]"
+        },
+        {
+            "description": "The input DWI image containing volumes that are both diffusion weighted and b=0",
+            "id": "input",
+            "name": "input",
+            "optional": false,
+            "type": "File",
+            "value-key": "[INPUT]"
+        },
+        {
+            "description": "The output whole brain mask image",
+            "id": "output_mask",
+            "name": "output_mask",
+            "optional": false,
+            "type": "String",
+            "value-key": "[OUTPUT]"
+        }
+    ],
+    "output-files": [
+        {
+            "id": "output_image",
+            "name": "Output mask image",
+            "description": "The output whole brain mask image",
+            "optional": false,
+            "path-template": "[OUTPUT].nii.gz",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii"
+            ]
+        }
+    ],
+    "schema-version": "0.5",
+    "suggested-resources": {
+        "cpu-cores": 1,
+        "ram": 2048,
+        "walltime-estimate": 20
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "image processing",
+            "mri",
+            "dwi",
+            "tractography"
+        ]
+    },
+    "tool-version": "v0.1.0"
+}

--- a/code/tractography/mrtrix/dwi2response_fa_desc.json
+++ b/code/tractography/mrtrix/dwi2response_fa_desc.json
@@ -1,0 +1,252 @@
+{
+    "command-line": "dwi2response fa [INPUT] [OUTPUT] [SHELLS] [LMAX] [MASK] [VOXELS] [GRAD] [FSLGRAD] [BVECS] [BVALS] [CONTINUE] [CTEMPDIR] [LASTFILE] [FORCE] [HELP] [NOCLEANUP] [NTHREADS] [TEMPDIR] [QUIET] [INFO] [DEBUG] [THRESHOLD] [NUMBER] [ERODE]",
+    "container-image": {
+        "image": "darrinfong/mrtrix3:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "tool-version": "3.0_RC3_latest",
+    "schema-version": "0.5",
+    "description": "Use the old FA-threshold heuristic for single-fibre voxel selection and response function estimation",
+    "name": "dwi2response fa",
+    "inputs": [
+        {
+            "command-line-flag": "-shells",
+            "description": "The b-value shell(s) to use in response function estimation (single value for single-shell response, comma-separated list for multi-shell response)",
+            "id": "shells",
+            "name": "Diffusion-weighted gradient shell(s)",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "value-key": "[SHELLS]"
+        },
+        {
+            "command-line-flag": "-lmax",
+            "description": "The maximum harmonic degree(s) of response function estimation (single value for single-shell response, comma-separated list for multi-shell response)",
+            "id": "lmax",
+            "name": "Maximum harmonic degree",
+            "optional": true,
+            "list": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[LMAX]"
+        },
+        {
+            "command-line-flag": "-mask",
+            "description": "Provide an initial mask for response voxel selection",
+            "id": "mask",
+            "name": "Initial mask image",
+            "optional": true,
+            "type": "File",
+            "value-key": "[MASK]"
+        },
+        {
+            "command-line-flag": "-voxels",
+            "description": "Output an image showing the final voxel selection(s)",
+            "id": "voxels",
+            "name": "single-fiber voxels",
+            "optional": true,
+            "type": "File",
+            "value-key": "[VOXELS]"
+        },
+        {
+            "command-line-flag": "-grad",
+            "description": "Pass the diffusion gradient table in MRtrix format",
+            "id": "grad",
+            "name": "grad",
+            "optional": true,
+            "type": "File",
+            "value-key": "[GRAD]"
+        },
+        {
+            "command-line-flag": "-fslgrad",
+            "description": "Pass the diffusion gradient table in FSL bvecs/bvals format",
+            "id": "fslgrad",
+            "name": "fslgrad",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FSLGRAD]",
+            "requires-inputs": ["bvecs", "bvals"]
+        },
+        {
+            "description": "Pass the diffusion gradient table in FSL bvecs format",
+            "id": "bvecs",
+            "name": "bvecs",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVECS]",
+            "requires-inputs": ["fslgrad", "bvals"]
+        },
+        {
+            "description": "Pass the diffusion gradient table in FSL bvals format",
+            "id": "bvals",
+            "name": "bvals",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVALS]",
+            "requires-inputs": ["fslgrad", "bvecs"]
+        },
+        {
+            "command-line-flag": "-continue",
+            "description": "Continue the script from a previous execution; must provide the temporary directory path, and the name of the last successfully-generated file",
+            "id": "continue",
+            "name": "continue",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[CONTINUE]",
+            "requires-inputs": ["ctempdir",  "lastfile"]
+        },
+        {
+            "description": "Temporary directory path",
+            "id": "ctempdir",
+            "name": "Temporary directory path",
+            "optional": true,
+            "type": "File",
+            "value-key": "[CTEMPDIR]",
+            "requires-inputs": ["continue",  "lastfile"]
+        },
+        {
+            "description": "Path to last successfully-generated file",
+            "id": "lastfile",
+            "name": "Last successfully-generated file",
+            "optional": true,
+            "type": "File",
+            "value-key": "[LASTFILE]",
+            "requires-inputs": ["continue",  "ctempdir"]
+        },
+        {
+            "command-line-flag": "-force",
+            "description": "Force overwrite of output files if pre-existing",
+            "id": "force",
+            "name": "force",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FORCE]"
+        },
+        {
+            "command-line-flag": "-help",
+            "description": "Display help information for the script",
+            "id": "help",
+            "name": "help",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HELP]"
+        },
+        {
+            "command-line-flag": "-nocleanup",
+            "description": "Do not delete temporary files during script, or temporary directory at script completion",
+            "id": "nocleanup",
+            "name": "nocleanup",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[NOCLEANUP]"
+        },
+        {
+            "command-line-flag": "-nthreads",
+            "description": "Use this number of threads in MRtrix multi-threaded applications (0 disables multi-threading)",
+            "id": "nthreads",
+            "name": "nthreads",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[NTHREADS]"
+        },
+        {
+            "command-line-flag": "-tempdir",
+            "description": "Manually specify the path in which to generate the temporary directory",
+            "id": "tempdir",
+            "name": "tempdir",
+            "optional": true,
+            "type": "File",
+            "value-key": "[TEMPDIR]"
+        },
+        {
+            "command-line-flag": "-quiet",
+            "description": "Suppress all console output during script execution",
+            "id": "quiet",
+            "name": "quiet",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[QUIET]",
+            "disables-inputs": ["info", "debug"]
+        },
+        {
+            "command-line-flag": "-info",
+            "description": "Display additional information and progress for every command invoked",
+            "id": "info",
+            "name": "info",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[INFO]",
+            "disables-inputs": ["quiet", "debug"]
+        },
+        {
+            "command-line-flag": "-debug",
+            "description": "Display additional debugging information over and above the output of -info",
+            "id": "debug",
+            "name": "debug",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DEBUG]",
+            "disables-inputs": ["info", "quiet"]
+        },
+        {
+            "id": "erode",
+            "name": "erode",
+            "description": "Number of brain mask erosion steps to apply prior to threshold (not used if mask is provided manually)",
+            "optional": true,
+            "integer": true,
+            "value-key": "[ERODE]",
+            "type": "Number",
+            "command-line-flag": "-erode"
+        },
+        {
+            "id": "number",
+            "name": "number",
+            "description": "The number of highest-FA voxels to use",
+            "optional": true,
+            "integer": true,
+            "value-key": "[NUMBER]",
+            "type": "Number",
+            "command-line-flag": "-number",
+            "disables-inputs": ["threshold"]
+        },
+        {
+            "id": "threshold",
+            "name": "threshold",
+            "description": "Apply a hard FA threshold, rather than selecting the top voxels",
+            "optional": true,
+            "value-key": "[THRESHOLD]",
+            "type": "Number",
+            "command-line-flag": "-threshold",
+            "disables-inputs": ["number"]
+        },
+        {
+            "id": "input",
+            "name": "input",
+            "description": "The input DWI",
+            "optional": false,
+            "value-key": "[INPUT]",
+            "type": "File"
+        },
+        {
+            "id": "output",
+            "name": "output",
+            "description": "The output response function text file",
+            "optional": false,
+            "value-key": "[OUTPUT]",
+            "type": "String"
+        }
+    ],
+    "output-files": [
+        {
+            "id": "output_response",
+            "name": "Output response function text file",
+            "optional": false,
+            "path-template": "[OUTPUT].txt",
+            "path-template-stripped-extensions": [
+                ".txt"
+            ]
+        }
+    ]
+}

--- a/code/tractography/mrtrix/dwi2response_hollander_desc.json
+++ b/code/tractography/mrtrix/dwi2response_hollander_desc.json
@@ -1,0 +1,306 @@
+{
+    "command-line": "dwi2response dhollander [SHELLS] [LMAX] [MASK] [VOXELS] [GRAD] [FSLGRAD] [BVECS] [BVALS] [CONTINUE] [CTEMPDIR] [LASTFILE] [FORCE] [HELP] [NOCLEANUP] [NTHREADS] [TEMPDIR] [QUIET] [INFO] [DEBUG] [ERODE] [FA] [SFWM] [GM] [CSF] [INPUT] [OUT_SFWM] [OUT_GM] [OUT_CSF]",
+    "container-image": {
+        "image": "darrinfong/mrtrix3:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "tool-version": "3.0_RC3_latest",
+    "schema-version": "0.5",
+    "description": "Use the Dhollander et al. (2016) algorithm for unsupervised estimation of WM, GM and CSF response functions; does not require a T1 image (or segmentation thereof)",
+    "name": "dwi2response dhollander",
+    "inputs": [
+        {
+            "command-line-flag": "-shells",
+            "description": "The b-value shell(s) to use in response function estimation (single value for single-shell response, comma-separated list for multi-shell response)",
+            "id": "shells",
+            "name": "Diffusion-weighted gradient shell(s)",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "value-key": "[SHELLS]"
+        },
+        {
+            "command-line-flag": "-lmax",
+            "description": "The maximum harmonic degree(s) of response function estimation (single value for single-shell response, comma-separated list for multi-shell response)",
+            "id": "lmax",
+            "name": "Maximum harmonic degree",
+            "optional": true,
+            "list": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[LMAX]"
+        },
+        {
+            "command-line-flag": "-mask",
+            "description": "Provide an initial mask for response voxel selection",
+            "id": "mask",
+            "name": "Initial mask image",
+            "optional": true,
+            "type": "File",
+            "value-key": "[MASK]"
+        },
+        {
+            "command-line-flag": "-voxels",
+            "description": "Output an image showing the final voxel selection(s)",
+            "id": "voxels",
+            "name": "single-fiber voxels",
+            "optional": true,
+            "type": "File",
+            "value-key": "[VOXELS]"
+        },
+        {
+            "command-line-flag": "-grad",
+            "description": "Pass the diffusion gradient table in MRtrix format",
+            "id": "grad",
+            "name": "grad",
+            "optional": true,
+            "type": "File",
+            "value-key": "[GRAD]"
+        },
+        {
+            "command-line-flag": "-fslgrad",
+            "description": "Pass the diffusion gradient table in FSL bvecs/bvals format",
+            "id": "fslgrad",
+            "name": "fslgrad",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FSLGRAD]",
+            "requires-inputs": ["bvecs", "bvals"]
+        },
+        {
+            "description": "Pass the diffusion gradient table in FSL bvecs format",
+            "id": "bvecs",
+            "name": "bvecs",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVECS]",
+            "requires-inputs": ["fslgrad", "bvals"]
+        },
+        {
+            "description": "Pass the diffusion gradient table in FSL bvals format",
+            "id": "bvals",
+            "name": "bvals",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVALS]",
+            "requires-inputs": ["fslgrad", "bvecs"]
+        },
+        {
+            "command-line-flag": "-continue",
+            "description": "Continue the script from a previous execution; must provide the temporary directory path, and the name of the last successfully-generated file",
+            "id": "continue",
+            "name": "continue",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[CONTINUE]",
+            "requires-inputs": ["ctempdir",  "lastfile"]
+        },
+        {
+            "description": "Temporary directory path",
+            "id": "ctempdir",
+            "name": "Temporary directory path",
+            "optional": true,
+            "type": "File",
+            "value-key": "[CTEMPDIR]",
+            "requires-inputs": ["continue",  "lastfile"]
+        },
+        {
+            "description": "Path to last successfully-generated file",
+            "id": "lastfile",
+            "name": "Last successfully-generated file",
+            "optional": true,
+            "type": "File",
+            "value-key": "[LASTFILE]",
+            "requires-inputs": ["continue",  "ctempdir"]
+        },
+        {
+            "command-line-flag": "-force",
+            "description": "Force overwrite of output files if pre-existing",
+            "id": "force",
+            "name": "force",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FORCE]"
+        },
+        {
+            "command-line-flag": "-help",
+            "description": "Display help information for the script",
+            "id": "help",
+            "name": "help",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HELP]"
+        },
+        {
+            "command-line-flag": "-nocleanup",
+            "description": "Do not delete temporary files during script, or temporary directory at script completion",
+            "id": "nocleanup",
+            "name": "nocleanup",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[NOCLEANUP]"
+        },
+        {
+            "command-line-flag": "-nthreads",
+            "description": "Use this number of threads in MRtrix multi-threaded applications (0 disables multi-threading)",
+            "id": "nthreads",
+            "name": "nthreads",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[NTHREADS]"
+        },
+        {
+            "command-line-flag": "-tempdir",
+            "description": "Manually specify the path in which to generate the temporary directory",
+            "id": "tempdir",
+            "name": "tempdir",
+            "optional": true,
+            "type": "File",
+            "value-key": "[TEMPDIR]"
+        },
+        {
+            "command-line-flag": "-quiet",
+            "description": "Suppress all console output during script execution",
+            "id": "quiet",
+            "name": "quiet",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[QUIET]",
+            "disables-inputs": ["info", "debug"]
+        },
+        {
+            "command-line-flag": "-info",
+            "description": "Display additional information and progress for every command invoked",
+            "id": "info",
+            "name": "info",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[INFO]",
+            "disables-inputs": ["quiet", "debug"]
+        },
+        {
+            "command-line-flag": "-debug",
+            "description": "Display additional debugging information over and above the output of -info",
+            "id": "debug",
+            "name": "debug",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DEBUG]",
+            "disables-inputs": ["info", "quiet"]
+        },
+        {
+            "id": "erode",
+            "name": "erode",
+            "description": "Number of erosion passes to apply to initial (whole brain) mask. [default: 3]",
+            "optional": true,
+            "value-key": "[ERODE]",
+            "integer": true,
+            "type": "Number",
+            "default-value": 3,
+            "command-line-flag": "-erode"
+        },
+        {
+            "id": "fa",
+            "name": "fa",
+            "description": "FA threshold for crude WM versus GM-CSF separation. [default: 0.2]",
+            "optional": true,
+            "value-key": "[FA]",
+            "type": "Number",
+            "default-value": 0.2,
+            "command-line-flag": "-fa"
+        },
+        {
+            "id": "sfwm",
+            "name": "sfwm",
+            "description": "Number of single-fibre WM voxels to select, as a percentage of refined WM. [default: 0.5]",
+            "optional": true,
+            "value-key": "[SFWM]",
+            "type": "Number",
+            "default-value": 0.5,
+            "command-line-flag": "-sfwm"
+        },
+        {
+            "id": "gm",
+            "name": "gm",
+            "description": "Number of GM voxels to select, as a percentage of refined GM. [default: 2]",
+            "optional": true,
+            "value-key": "[GM]",
+            "type": "Number",
+            "default-value": 2,
+            "command-line-flag": "-gm"
+        },
+        {
+            "id": "csf",
+            "name": "csf",
+            "description": "Number of CSF voxels to select, as a percentage of refined CSF. [default: 10])",
+            "optional": true,
+            "value-key": "[CSF]",
+            "type": "Number",
+            "default-value": 1,
+            "command-line-flag": "-csf"
+        },
+        {
+            "id": "input",
+            "name": "input",
+            "description": "The input DWI",
+            "optional": false,
+            "value-key": "[INPUT]",
+            "type": "File"
+        },
+        {
+            "id": "out_sfwm",
+            "name": "out sfwm",
+            "description": "Output single-fibre WM response text file",
+            "optional": false,
+            "value-key": "[OUT_SFWM]",
+            "type": "String"
+        },
+        {
+            "id": "out_gm",
+            "name": "out gm",
+            "description": "Output GM response text file",
+            "optional": false,
+            "value-key": "[OUT_GM]",
+            "type": "String"
+        },
+        {
+            "id": "out_csf",
+            "name": "out csf",
+            "description": "Output CSF response text file",
+            "optional": false,
+            "value-key": "[OUT_CSF]",
+            "type": "String"
+        }
+    ],
+    "output-files": [
+        {
+            "id": "output_sfwm",
+            "name": "Output single-fibre WM response text file",
+            "optional": false,
+            "path-template": "[OUT_SFWM].txt",
+            "path-template-stripped-extensions": [
+                ".txt"
+            ]
+        },
+        {
+            "id": "output_gm",
+            "name": "Output GM response text file",
+            "optional": false,
+            "path-template": "[OUT_GM].txt",
+            "path-template-stripped-extensions": [
+                ".txt"
+            ]
+        },
+        {
+            "id": "output_csf",
+            "name": "Output CSF response text file",
+            "optional": false,
+            "path-template": "[OUT_CSF].txt",
+            "path-template-stripped-extensions": [
+                ".txt"
+            ]
+        }
+    ]
+}

--- a/code/tractography/mrtrix/dwi2response_manual_desc.json
+++ b/code/tractography/mrtrix/dwi2response_manual_desc.json
@@ -1,0 +1,238 @@
+{
+    "command-line": "dwi2response manual [SHELLS] [LMAX] [MASK] [VOXELS] [GRAD] [FSLGRAD] [BVECS] [BVALS] [CONTINUE] [CTEMPDIR] [LASTFILE] [FORCE] [HELP] [NOCLEANUP] [NTHREADS] [TEMPDIR] [QUIET] [INFO] [DEBUG] [DIRS] [INPUT] [IN_VOXELS] [OUTPUT]",
+    "container-image": {
+        "image": "darrinfong/mrtrix3:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "tool-version": "3.0_RC3_latest",
+    "schema-version": "0.5",
+    "description": "Derive a response function using an input mask image alone (i.e. pre- selected voxels)",
+    "name": "dwi2response manual",
+    "inputs": [
+        {
+            "command-line-flag": "-shells",
+            "description": "The b-value shell(s) to use in response function estimation (single value for single-shell response, comma-separated list for multi-shell response)",
+            "id": "shells",
+            "name": "Diffusion-weighted gradient shell(s)",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "value-key": "[SHELLS]"
+        },
+        {
+            "command-line-flag": "-lmax",
+            "description": "The maximum harmonic degree(s) of response function estimation (single value for single-shell response, comma-separated list for multi-shell response)",
+            "id": "lmax",
+            "name": "Maximum harmonic degree",
+            "optional": true,
+            "list": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[LMAX]"
+        },
+        {
+            "command-line-flag": "-mask",
+            "description": "Provide an initial mask for response voxel selection",
+            "id": "mask",
+            "name": "Initial mask image",
+            "optional": true,
+            "type": "File",
+            "value-key": "[MASK]"
+        },
+        {
+            "command-line-flag": "-voxels",
+            "description": "Output an image showing the final voxel selection(s)",
+            "id": "voxels",
+            "name": "single-fiber voxels",
+            "optional": true,
+            "type": "File",
+            "value-key": "[VOXELS]"
+        },
+        {
+            "command-line-flag": "-grad",
+            "description": "Pass the diffusion gradient table in MRtrix format",
+            "id": "grad",
+            "name": "grad",
+            "optional": true,
+            "type": "File",
+            "value-key": "[GRAD]"
+        },
+        {
+            "command-line-flag": "-fslgrad",
+            "description": "Pass the diffusion gradient table in FSL bvecs/bvals format",
+            "id": "fslgrad",
+            "name": "fslgrad",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FSLGRAD]",
+            "requires-inputs": ["bvecs", "bvals"]
+        },
+        {
+            "description": "Pass the diffusion gradient table in FSL bvecs format",
+            "id": "bvecs",
+            "name": "bvecs",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVECS]",
+            "requires-inputs": ["fslgrad", "bvals"]
+        },
+        {
+            "description": "Pass the diffusion gradient table in FSL bvals format",
+            "id": "bvals",
+            "name": "bvals",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVALS]",
+            "requires-inputs": ["fslgrad", "bvecs"]
+        },
+        {
+            "command-line-flag": "-continue",
+            "description": "Continue the script from a previous execution; must provide the temporary directory path, and the name of the last successfully-generated file",
+            "id": "continue",
+            "name": "continue",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[CONTINUE]",
+            "requires-inputs": ["ctempdir",  "lastfile"]
+        },
+        {
+            "description": "Temporary directory path",
+            "id": "ctempdir",
+            "name": "Temporary directory path",
+            "optional": true,
+            "type": "File",
+            "value-key": "[CTEMPDIR]",
+            "requires-inputs": ["continue",  "lastfile"]
+        },
+        {
+            "description": "Path to last successfully-generated file",
+            "id": "lastfile",
+            "name": "Last successfully-generated file",
+            "optional": true,
+            "type": "File",
+            "value-key": "[LASTFILE]",
+            "requires-inputs": ["continue",  "ctempdir"]
+        },
+        {
+            "command-line-flag": "-force",
+            "description": "Force overwrite of output files if pre-existing",
+            "id": "force",
+            "name": "force",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FORCE]"
+        },
+        {
+            "command-line-flag": "-help",
+            "description": "Display help information for the script",
+            "id": "help",
+            "name": "help",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HELP]"
+        },
+        {
+            "command-line-flag": "-nocleanup",
+            "description": "Do not delete temporary files during script, or temporary directory at script completion",
+            "id": "nocleanup",
+            "name": "nocleanup",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[NOCLEANUP]"
+        },
+        {
+            "command-line-flag": "-nthreads",
+            "description": "Use this number of threads in MRtrix multi-threaded applications (0 disables multi-threading)",
+            "id": "nthreads",
+            "name": "nthreads",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[NTHREADS]"
+        },
+        {
+            "command-line-flag": "-tempdir",
+            "description": "Manually specify the path in which to generate the temporary directory",
+            "id": "tempdir",
+            "name": "tempdir",
+            "optional": true,
+            "type": "File",
+            "value-key": "[TEMPDIR]"
+        },
+        {
+            "command-line-flag": "-quiet",
+            "description": "Suppress all console output during script execution",
+            "id": "quiet",
+            "name": "quiet",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[QUIET]",
+            "disables-inputs": ["info", "debug"]
+        },
+        {
+            "command-line-flag": "-info",
+            "description": "Display additional information and progress for every command invoked",
+            "id": "info",
+            "name": "info",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[INFO]",
+            "disables-inputs": ["quiet", "debug"]
+        },
+        {
+            "command-line-flag": "-debug",
+            "description": "Display additional debugging information over and above the output of -info",
+            "id": "debug",
+            "name": "debug",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DEBUG]",
+            "disables-inputs": ["info", "quiet"]
+        },
+        {
+            "id": "dirs",
+            "name": "dirs",
+            "description": "Manually provide the fibre direction in each voxel (a tensor fit will be used otherwise)",
+            "optional": true,
+            "value-key": "[DIRS]",
+            "type": "File",
+            "command-line-flag": "-dirs"
+        },
+        {
+            "id": "input",
+            "name": "input",
+            "description": "The input DWI",
+            "optional": false,
+            "value-key": "[INPUT]",
+            "type": "File"
+        },
+        {
+            "id": "in_voxels",
+            "name": "in voxels",
+            "description": "Input voxel selection mask",
+            "optional": false,
+            "value-key": "[IN_VOXELS]",
+            "type": "File"
+        },
+        {
+            "id": "output",
+            "name": "output",
+            "description": "Output response function text file",
+            "optional": false,
+            "value-key": "[OUTPUT]",
+            "type": "String"
+        }
+    ],
+    "output-files": [
+        {
+            "id": "output_response",
+            "name": "Output response function text file",
+            "optional": false,
+            "path-template": "[OUTPUT].txt",
+            "path-template-stripped-extensions": [
+                ".txt"
+            ]
+        }
+    ]
+}

--- a/code/tractography/mrtrix/dwi2response_msmt_5tt_desc.json
+++ b/code/tractography/mrtrix/dwi2response_msmt_5tt_desc.json
@@ -1,0 +1,312 @@
+{
+    "command-line": "dwi2response msmt_5tt [SHELLS] [LMAX] [MASK] [VOXELS] [GRAD] [FSLGRAD] [BVECS] [BVALS] [CONTINUE] [CTEMPDIR] [LASTFILE] [FORCE] [HELP] [NOCLEANUP] [NTHREADS] [TEMPDIR] [QUIET] [INFO] [DEBUG] [DIRS] [FA] [SFWM_FA_THRESHOLD] [WM_ALGO] [PVF] [INPUT] [IN_5TT] [OUT_WM] [OUT_GM] [OUT_CSF]",
+    "container-image": {
+        "image": "darrinfong/mrtrix3:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "tool-version": "3.0_RC3_latest",
+    "schema-version": "0.5",
+    "description": "Derive MSMT-CSD tissue response functions based on a co-registered five- tissue-type (5TT) image",
+    "name": "dwi2response msmt_5tt",
+    "inputs": [
+        {
+            "command-line-flag": "-shells",
+            "description": "The b-value shell(s) to use in response function estimation (single value for single-shell response, comma-separated list for multi-shell response)",
+            "id": "shells",
+            "name": "Diffusion-weighted gradient shell(s)",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "value-key": "[SHELLS]"
+        },
+        {
+            "command-line-flag": "-lmax",
+            "description": "The maximum harmonic degree(s) of response function estimation (single value for single-shell response, comma-separated list for multi-shell response)",
+            "id": "lmax",
+            "name": "Maximum harmonic degree",
+            "optional": true,
+            "list": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[LMAX]"
+        },
+        {
+            "command-line-flag": "-mask",
+            "description": "Provide an initial mask for response voxel selection",
+            "id": "mask",
+            "name": "Initial mask image",
+            "optional": true,
+            "type": "File",
+            "value-key": "[MASK]"
+        },
+        {
+            "command-line-flag": "-voxels",
+            "description": "Output an image showing the final voxel selection(s)",
+            "id": "voxels",
+            "name": "single-fiber voxels",
+            "optional": true,
+            "type": "File",
+            "value-key": "[VOXELS]"
+        },
+        {
+            "command-line-flag": "-grad",
+            "description": "Pass the diffusion gradient table in MRtrix format",
+            "id": "grad",
+            "name": "grad",
+            "optional": true,
+            "type": "File",
+            "value-key": "[GRAD]"
+        },
+        {
+            "command-line-flag": "-fslgrad",
+            "description": "Pass the diffusion gradient table in FSL bvecs/bvals format",
+            "id": "fslgrad",
+            "name": "fslgrad",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FSLGRAD]",
+            "requires-inputs": ["bvecs", "bvals"]
+        },
+        {
+            "description": "Pass the diffusion gradient table in FSL bvecs format",
+            "id": "bvecs",
+            "name": "bvecs",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVECS]",
+            "requires-inputs": ["fslgrad", "bvals"]
+        },
+        {
+            "description": "Pass the diffusion gradient table in FSL bvals format",
+            "id": "bvals",
+            "name": "bvals",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVALS]",
+            "requires-inputs": ["fslgrad", "bvecs"]
+        },
+        {
+            "command-line-flag": "-continue",
+            "description": "Continue the script from a previous execution; must provide the temporary directory path, and the name of the last successfully-generated file",
+            "id": "continue",
+            "name": "continue",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[CONTINUE]",
+            "requires-inputs": ["ctempdir",  "lastfile"]
+        },
+        {
+            "description": "Temporary directory path",
+            "id": "ctempdir",
+            "name": "Temporary directory path",
+            "optional": true,
+            "type": "File",
+            "value-key": "[CTEMPDIR]",
+            "requires-inputs": ["continue",  "lastfile"]
+        },
+        {
+            "description": "Path to last successfully-generated file",
+            "id": "lastfile",
+            "name": "Last successfully-generated file",
+            "optional": true,
+            "type": "File",
+            "value-key": "[LASTFILE]",
+            "requires-inputs": ["continue",  "ctempdir"]
+        },
+        {
+            "command-line-flag": "-force",
+            "description": "Force overwrite of output files if pre-existing",
+            "id": "force",
+            "name": "force",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FORCE]"
+        },
+        {
+            "command-line-flag": "-help",
+            "description": "Display help information for the script",
+            "id": "help",
+            "name": "help",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HELP]"
+        },
+        {
+            "command-line-flag": "-nocleanup",
+            "description": "Do not delete temporary files during script, or temporary directory at script completion",
+            "id": "nocleanup",
+            "name": "nocleanup",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[NOCLEANUP]"
+        },
+        {
+            "command-line-flag": "-nthreads",
+            "description": "Use this number of threads in MRtrix multi-threaded applications (0 disables multi-threading)",
+            "id": "nthreads",
+            "name": "nthreads",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[NTHREADS]"
+        },
+        {
+            "command-line-flag": "-tempdir",
+            "description": "Manually specify the path in which to generate the temporary directory",
+            "id": "tempdir",
+            "name": "tempdir",
+            "optional": true,
+            "type": "File",
+            "value-key": "[TEMPDIR]"
+        },
+        {
+            "command-line-flag": "-quiet",
+            "description": "Suppress all console output during script execution",
+            "id": "quiet",
+            "name": "quiet",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[QUIET]",
+            "disables-inputs": ["info", "debug"]
+        },
+        {
+            "command-line-flag": "-info",
+            "description": "Display additional information and progress for every command invoked",
+            "id": "info",
+            "name": "info",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[INFO]",
+            "disables-inputs": ["quiet", "debug"]
+        },
+        {
+            "command-line-flag": "-debug",
+            "description": "Display additional debugging information over and above the output of -info",
+            "id": "debug",
+            "name": "debug",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DEBUG]",
+            "disables-inputs": ["info", "quiet"]
+        },
+        {
+            "id": "dirs",
+            "name": "dirs",
+            "description": "Manually provide the fibre direction in each voxel (a tensor fit will be used otherwise)",
+            "optional": true,
+            "value-key": "[DIRS]",
+            "type": "String",
+            "command-line-flag": "-dirs"
+        },
+        {
+            "id": "fa",
+            "name": "fa",
+            "description": "Upper fractional anisotropy threshold for GM and CSF voxel selection (default: 0.2)",
+            "optional": true,
+            "value-key": "[FA]",
+            "type": "Number",
+            "default-value": 0.2,
+            "command-line-flag": "-fa"
+        },
+        {
+            "id": "sfwm_fa_threshold",
+            "name": "sfwm fa threshold",
+            "description": "Sets -wm_algo to fa and allows to specify a hard FA threshold for single- fibre WM voxels, which is passed to the -threshold option of the fa algorithm (warning: overrides -wm_algo option)",
+            "optional": true,
+            "value-key": "[SFWM_FA_THRESHOLD]",
+            "type": "Number",
+            "command-line-flag": "-sfwm_fa_threshold"
+        },
+        {
+            "id": "wm_algo",
+            "name": "wm algo",
+            "description": "dwi2response algorithm to use for WM single-fibre voxel selection (default: tournier)",
+            "optional": true,
+            "value-key": "[WM_ALGO]",
+            "type": "String",
+            "value-choices": ["dhollander", "fa", "manual", "msmt_5tt", "tax", "tournier"],
+            "default-value": "tournier",
+            "command-line-flag": "-wm_algo"
+        },
+        {
+            "id": "pvf",
+            "name": "pvf",
+            "description": "Partial volume fraction threshold for tissue voxel selection (default: 0.95)",
+            "optional": true,
+            "value-key": "[PVF]",
+            "type": "Number",
+            "default-value": 0.95,
+            "command-line-flag": "-pvf"
+        },
+        {
+            "id": "input",
+            "name": "input",
+            "description": "The input DWI",
+            "optional": false,
+            "value-key": "[INPUT]",
+            "type": "File"
+        },
+        {
+            "id": "in_5tt",
+            "name": "in 5tt",
+            "description": "Input co-registered 5TT image",
+            "optional": false,
+            "value-key": "[IN_5TT]",
+            "type": "File"
+        },
+        {
+            "id": "out_wm",
+            "name": "out wm",
+            "description": "Output WM response text file",
+            "optional": false,
+            "value-key": "[OUT_WM]",
+            "type": "String"
+        },
+        {
+            "id": "out_gm",
+            "name": "out gm",
+            "description": "Output GM response text file",
+            "optional": false,
+            "value-key": "[OUT_GM]",
+            "type": "String"
+        },
+        {
+            "id": "out_csf",
+            "name": "out csf",
+            "description": "Output CSF response text file",
+            "optional": false,
+            "value-key": "[OUT_CSF]",
+            "type": "String"
+        }
+    ],
+    "output-files": [
+        {
+            "id": "output_wm",
+            "name": "Output WM response text file",
+            "optional": false,
+            "path-template": "[OUT_WM].txt",
+            "path-template-stripped-extensions": [
+                ".txt"
+            ]
+        },
+        {
+            "id": "output_gm",
+            "name": "Output GM response text file",
+            "optional": false,
+            "path-template": "[OUT_GM].txt",
+            "path-template-stripped-extensions": [
+                ".txt"
+            ]
+        },
+        {
+            "id": "output_csf",
+            "name": "Output CSF response text file",
+            "optional": false,
+            "path-template": "[OUT_CSF].txt",
+            "path-template-stripped-extensions": [
+                ".txt"
+            ]
+        }
+    ]
+}

--- a/code/tractography/mrtrix/dwi2response_tax_desc.json
+++ b/code/tractography/mrtrix/dwi2response_tax_desc.json
@@ -1,0 +1,248 @@
+{
+    "command-line": "dwi2response tax [SHELLS] [LMAX] [MASK] [VOXELS] [GRAD] [FSLGRAD] [BVECS] [BVALS] [CONTINUE] [CTEMPDIR] [LASTFILE] [FORCE] [HELP] [NOCLEANUP] [NTHREADS] [TEMPDIR] [QUIET] [INFO] [DEBUG] [CONVERGENCE] [PEAK_RATIO] [MAX_ITERS] [INPUT] [OUTPUT]",
+    "container-image": {
+        "image": "darrinfong/mrtrix3:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "tool-version": "3.0_RC3_latest",
+    "schema-version": "0.5",
+    "description": "Use the Tax et al. (2014) recursive calibration algorithm for single-fibre voxel selection and response function estimation",
+    "name": "dwi2response tax",
+    "inputs": [
+        {
+            "command-line-flag": "-shells",
+            "description": "The b-value shell(s) to use in response function estimation (single value for single-shell response, comma-separated list for multi-shell response)",
+            "id": "shells",
+            "name": "Diffusion-weighted gradient shell(s)",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "value-key": "[SHELLS]"
+        },
+        {
+            "command-line-flag": "-lmax",
+            "description": "The maximum harmonic degree(s) of response function estimation (single value for single-shell response, comma-separated list for multi-shell response)",
+            "id": "lmax",
+            "name": "Maximum harmonic degree",
+            "optional": true,
+            "list": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[LMAX]"
+        },
+        {
+            "command-line-flag": "-mask",
+            "description": "Provide an initial mask for response voxel selection",
+            "id": "mask",
+            "name": "Initial mask image",
+            "optional": true,
+            "type": "File",
+            "value-key": "[MASK]"
+        },
+        {
+            "command-line-flag": "-voxels",
+            "description": "Output an image showing the final voxel selection(s)",
+            "id": "voxels",
+            "name": "single-fiber voxels",
+            "optional": true,
+            "type": "File",
+            "value-key": "[VOXELS]"
+        },
+        {
+            "command-line-flag": "-grad",
+            "description": "Pass the diffusion gradient table in MRtrix format",
+            "id": "grad",
+            "name": "grad",
+            "optional": true,
+            "type": "File",
+            "value-key": "[GRAD]"
+        },
+        {
+            "command-line-flag": "-fslgrad",
+            "description": "Pass the diffusion gradient table in FSL bvecs/bvals format",
+            "id": "fslgrad",
+            "name": "fslgrad",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FSLGRAD]",
+            "requires-inputs": ["bvecs", "bvals"]
+        },
+        {
+            "description": "Pass the diffusion gradient table in FSL bvecs format",
+            "id": "bvecs",
+            "name": "bvecs",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVECS]",
+            "requires-inputs": ["fslgrad", "bvals"]
+        },
+        {
+            "description": "Pass the diffusion gradient table in FSL bvals format",
+            "id": "bvals",
+            "name": "bvals",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVALS]",
+            "requires-inputs": ["fslgrad", "bvecs"]
+        },
+        {
+            "command-line-flag": "-continue",
+            "description": "Continue the script from a previous execution; must provide the temporary directory path, and the name of the last successfully-generated file",
+            "id": "continue",
+            "name": "continue",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[CONTINUE]",
+            "requires-inputs": ["ctempdir",  "lastfile"]
+        },
+        {
+            "description": "Temporary directory path",
+            "id": "ctempdir",
+            "name": "Temporary directory path",
+            "optional": true,
+            "type": "File",
+            "value-key": "[CTEMPDIR]",
+            "requires-inputs": ["continue",  "lastfile"]
+        },
+        {
+            "description": "Path to last successfully-generated file",
+            "id": "lastfile",
+            "name": "Last successfully-generated file",
+            "optional": true,
+            "type": "File",
+            "value-key": "[LASTFILE]",
+            "requires-inputs": ["continue",  "ctempdir"]
+        },
+        {
+            "command-line-flag": "-force",
+            "description": "Force overwrite of output files if pre-existing",
+            "id": "force",
+            "name": "force",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FORCE]"
+        },
+        {
+            "command-line-flag": "-help",
+            "description": "Display help information for the script",
+            "id": "help",
+            "name": "help",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HELP]"
+        },
+        {
+            "command-line-flag": "-nocleanup",
+            "description": "Do not delete temporary files during script, or temporary directory at script completion",
+            "id": "nocleanup",
+            "name": "nocleanup",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[NOCLEANUP]"
+        },
+        {
+            "command-line-flag": "-nthreads",
+            "description": "Use this number of threads in MRtrix multi-threaded applications (0 disables multi-threading)",
+            "id": "nthreads",
+            "name": "nthreads",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[NTHREADS]"
+        },
+        {
+            "command-line-flag": "-tempdir",
+            "description": "Manually specify the path in which to generate the temporary directory",
+            "id": "tempdir",
+            "name": "tempdir",
+            "optional": true,
+            "type": "File",
+            "value-key": "[TEMPDIR]"
+        },
+        {
+            "command-line-flag": "-quiet",
+            "description": "Suppress all console output during script execution",
+            "id": "quiet",
+            "name": "quiet",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[QUIET]",
+            "disables-inputs": ["info", "debug"]
+        },
+        {
+            "command-line-flag": "-info",
+            "description": "Display additional information and progress for every command invoked",
+            "id": "info",
+            "name": "info",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[INFO]",
+            "disables-inputs": ["quiet", "debug"]
+        },
+        {
+            "command-line-flag": "-debug",
+            "description": "Display additional debugging information over and above the output of -info",
+            "id": "debug",
+            "name": "debug",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DEBUG]",
+            "disables-inputs": ["info", "quiet"]
+        },
+        {
+            "id": "convergence",
+            "name": "convergence",
+            "description": "Percentile change in any RF coefficient required to continue iterating",
+            "optional": true,
+            "value-key": "[CONVERGENCE]",
+            "type": "Number",
+            "command-line-flag": "-convergence"
+        },
+        {
+            "id": "peak_ratio",
+            "name": "peak ratio",
+            "description": "Second-to-first-peak amplitude ratio threshold",
+            "optional": true,
+            "value-key": "[PEAK_RATIO]",
+            "type": "Number",
+            "command-line-flag": "-peak_ratio"
+        },
+        {
+            "id": "max_iters",
+            "name": "max iters",
+            "description": "Maximum number of iterations",
+            "optional": true,
+            "value-key": "[MAX_ITERS]",
+            "type": "Number",
+            "command-line-flag": "-max_iters"
+        },
+        {
+            "id": "input",
+            "name": "input",
+            "description": "The input DWI",
+            "optional": false,
+            "value-key": "[INPUT]",
+            "type": "File"
+        },
+        {
+            "id": "output",
+            "name": "output",
+            "description": "The output response function text file",
+            "optional": false,
+            "value-key": "[OUTPUT]",
+            "type": "String"
+        }
+    ],
+    "output-files": [
+        {
+            "id": "output_response",
+            "name": "Output response function text file",
+            "optional": false,
+            "path-template": "[OUTPUT].txt",
+            "path-template-stripped-extensions": [
+                ".txt"
+            ]
+        }
+    ]
+}

--- a/code/tractography/mrtrix/dwi2response_tournier_desc.json
+++ b/code/tractography/mrtrix/dwi2response_tournier_desc.json
@@ -1,0 +1,261 @@
+{
+    "command-line": "dwi2response tournier [SHELLS] [LMAX] [MASK] [VOXELS] [GRAD] [FSLGRAD] [BVECS] [BVALS] [CONTINUE] [CTEMPDIR] [LASTFILE] [FORCE] [HELP] [NOCLEANUP] [NTHREADS] [TEMPDIR] [QUIET] [INFO] [DEBUG] [SF_VOXELS] [DILATE] [MAX_ITERS] [ITER_VOXELS] [INPUT] [OUTPUT]",
+    "container-image": {
+        "image": "darrinfong/mrtrix3:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "tool-version": "3.0_RC3_latest",
+    "schema-version": "0.5",
+    "description": "Use the Tournier et al. (2013) iterative algorithm for single-fibre voxel selection and response function estimation",
+    "name": "dwi2response tournier",
+    "inputs": [
+        {
+            "command-line-flag": "-shells",
+            "description": "The b-value shell(s) to use in response function estimation (single value for single-shell response, comma-separated list for multi-shell response)",
+            "id": "shells",
+            "name": "Diffusion-weighted gradient shell(s)",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "value-key": "[SHELLS]"
+        },
+        {
+            "command-line-flag": "-lmax",
+            "description": "The maximum harmonic degree(s) of response function estimation (single value for single-shell response, comma-separated list for multi-shell response)",
+            "id": "lmax",
+            "name": "Maximum harmonic degree",
+            "optional": true,
+            "list": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[LMAX]"
+        },
+        {
+            "command-line-flag": "-mask",
+            "description": "Provide an initial mask for response voxel selection",
+            "id": "mask",
+            "name": "Initial mask image",
+            "optional": true,
+            "type": "File",
+            "value-key": "[MASK]"
+        },
+        {
+            "command-line-flag": "-voxels",
+            "description": "Output an image showing the final voxel selection(s)",
+            "id": "voxels",
+            "name": "single-fiber voxels",
+            "optional": true,
+            "type": "File",
+            "value-key": "[VOXELS]"
+        },
+        {
+            "command-line-flag": "-grad",
+            "description": "Pass the diffusion gradient table in MRtrix format",
+            "id": "grad",
+            "name": "grad",
+            "optional": true,
+            "type": "File",
+            "value-key": "[GRAD]"
+        },
+        {
+            "command-line-flag": "-fslgrad",
+            "description": "Pass the diffusion gradient table in FSL bvecs/bvals format",
+            "id": "fslgrad",
+            "name": "fslgrad",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FSLGRAD]",
+            "requires-inputs": ["bvecs", "bvals"]
+        },
+        {
+            "description": "Pass the diffusion gradient table in FSL bvecs format",
+            "id": "bvecs",
+            "name": "bvecs",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVECS]",
+            "requires-inputs": ["fslgrad", "bvals"]
+        },
+        {
+            "description": "Pass the diffusion gradient table in FSL bvals format",
+            "id": "bvals",
+            "name": "bvals",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVALS]",
+            "requires-inputs": ["fslgrad", "bvecs"]
+        },
+        {
+            "command-line-flag": "-continue",
+            "description": "Continue the script from a previous execution; must provide the temporary directory path, and the name of the last successfully-generated file",
+            "id": "continue",
+            "name": "continue",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[CONTINUE]",
+            "requires-inputs": ["ctempdir",  "lastfile"]
+        },
+        {
+            "description": "Temporary directory path",
+            "id": "ctempdir",
+            "name": "Temporary directory path",
+            "optional": true,
+            "type": "File",
+            "value-key": "[CTEMPDIR]",
+            "requires-inputs": ["continue",  "lastfile"]
+        },
+        {
+            "description": "Path to last successfully-generated file",
+            "id": "lastfile",
+            "name": "Last successfully-generated file",
+            "optional": true,
+            "type": "File",
+            "value-key": "[LASTFILE]",
+            "requires-inputs": ["continue",  "ctempdir"]
+        },
+        {
+            "command-line-flag": "-force",
+            "description": "Force overwrite of output files if pre-existing",
+            "id": "force",
+            "name": "force",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FORCE]"
+        },
+        {
+            "command-line-flag": "-help",
+            "description": "Display help information for the script",
+            "id": "help",
+            "name": "help",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HELP]"
+        },
+        {
+            "command-line-flag": "-nocleanup",
+            "description": "Do not delete temporary files during script, or temporary directory at script completion",
+            "id": "nocleanup",
+            "name": "nocleanup",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[NOCLEANUP]"
+        },
+        {
+            "command-line-flag": "-nthreads",
+            "description": "Use this number of threads in MRtrix multi-threaded applications (0 disables multi-threading)",
+            "id": "nthreads",
+            "name": "nthreads",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[NTHREADS]"
+        },
+        {
+            "command-line-flag": "-tempdir",
+            "description": "Manually specify the path in which to generate the temporary directory",
+            "id": "tempdir",
+            "name": "tempdir",
+            "optional": true,
+            "type": "File",
+            "value-key": "[TEMPDIR]"
+        },
+        {
+            "command-line-flag": "-quiet",
+            "description": "Suppress all console output during script execution",
+            "id": "quiet",
+            "name": "quiet",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[QUIET]",
+            "disables-inputs": ["info", "debug"]
+        },
+        {
+            "command-line-flag": "-info",
+            "description": "Display additional information and progress for every command invoked",
+            "id": "info",
+            "name": "info",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[INFO]",
+            "disables-inputs": ["quiet", "debug"]
+        },
+        {
+            "command-line-flag": "-debug",
+            "description": "Display additional debugging information over and above the output of -info",
+            "id": "debug",
+            "name": "debug",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DEBUG]",
+            "disables-inputs": ["info", "quiet"]
+        },
+        {
+            "id": "sf_voxels",
+            "name": "sf voxels",
+            "description": "Number of single-fibre voxels to use when calculating response function",
+            "optional": true,
+            "value-key": "[SF_VOXELS]",
+            "type": "Number",
+            "integer": true,
+            "command-line-flag": "-sf_voxels"
+        },
+        {
+            "id": "dilate",
+            "name": "dilate",
+            "description": "Number of mask dilation steps to apply when deriving voxel mask to test in the next iteration",
+            "optional": true,
+            "value-key": "[DILATE]",
+            "type": "Number",
+            "integer": true,
+            "command-line-flag": "-dilate"
+        },
+        {
+            "id": "max_iters",
+            "name": "max iters",
+            "description": "Maximum number of iterations",
+            "optional": true,
+            "value-key": "[MAX_ITERS]",
+            "type": "Number",
+            "integer": true,
+            "command-line-flag": "-max_iters"
+        },
+        {
+            "id": "iter_voxels",
+            "name": "iter voxels",
+            "description": "Number of single-fibre voxels to select when preparing for the next iteration",
+            "optional": true,
+            "value-key": "[ITER_VOXELS]",
+            "type": "Number",
+            "integer": true,
+            "command-line-flag": "-iter_voxels"
+        },
+        {
+            "id": "input",
+            "name": "input",
+            "description": "The input DWI",
+            "optional": false,
+            "value-key": "[INPUT]",
+            "type": "String"
+        },
+        {
+            "id": "output",
+            "name": "output",
+            "description": "The output response function text file",
+            "optional": false,
+            "value-key": "[OUTPUT]",
+            "type": "String"
+        }
+    ],
+    "output-files": [
+        {
+            "id": "output_response",
+            "name": "Output response function text file",
+            "optional": false,
+            "path-template": "[OUTPUT].txt",
+            "path-template-stripped-extensions": [
+                ".txt"
+            ]
+        }
+    ]
+}

--- a/code/tractography/mrtrix/mrtrixPpline.py
+++ b/code/tractography/mrtrix/mrtrixPpline.py
@@ -1,0 +1,80 @@
+from boutiques.descriptor2func import function
+from argparse import ArgumentParser
+
+def main(args=None):
+	parser = ArgumentParser("mrtrixPpline.py")
+	parser.add_argument("diffusion_image")
+	parser.add_argument("bvecs",
+                        help="The b-vectors corresponding to the diffusion "
+                             "images. If the images have been preprocessed "
+                             "then the rotated b-vectors should be used.")
+	parser.add_argument("bvals",
+                        help="The b-values corresponding to the diffusion "
+                             "images. ")
+	parser.add_argument("nodes")
+	parser.add_argument("output_directory",
+                        help="The directory in which the streamlines and "
+                             "optionally graphs and figures will be saved in.")
+	parser.add_argument("--whitematter_mask", "-wm")
+	parser.add_argument("--response", "-r")
+	parser.add_argument("--output_start", "-o",
+			help="Affects how the output files called. (e.g. '-o sub-A0000' will give output files sub-A0000_output_mask.nii.gz")
+
+	results = parser.parse_args() if args is None else parser.parse_args(args)
+
+	if results is None:
+		return 0
+
+	if results.output_start is None:
+		results.output_start = "mrtrixPpline"
+
+	results.output_styling = results.output_directory+results.output_start
+
+	if results.whitematter_mask is None:
+		dwi2mask = function("dwi2mask_desc.json")
+		mask_out = dwi2mask(input=results.diffusion_image, 
+							bvals=results.bvals,
+							bvecs=results.bvecs,
+							fslgrad=True,
+							output_mask=results.output_styling+"_output_mask.nii.gz")
+		print(mask_out)
+		results.whitematter_mask = results.output_styling+"_output_mask.nii.gz"
+
+	if results.response is None:
+		dwi2response = function("dwi2response_tournier_desc.json")
+		response_out = dwi2response(input=results.diffusion_image, 
+									bvals=results.bvals,
+									bvecs=results.bvecs,
+									fslgrad=True,
+									output=results.output_styling+"_output_response.txt")
+		print(response_out)
+		results.response = results.output_styling+"_output_response.txt"
+
+	dwi2fod = function("dwi2fod_desc.json")
+	fod_out = dwi2fod(algorithm="csd",
+						dwi=results.diffusion_image, 
+						bvals=results.bvals,
+						bvecs=results.bvecs,
+						fslgrad=True,
+						odf=results.output_styling+"_output_fod.nii.gz",
+						mask=results.whitematter_mask,
+    response=results.response)
+	print(fod_out)
+
+	tckgen = function("tckgen_desc.json")
+	tck_out = tckgen(seed_image=results.diffusion_image, 
+						bvals=results.bvals,
+						bvecs=results.bvecs,
+						fslgrad=True,
+						source=results.output_styling+"_output_fod.nii.gz",
+						tracks=results.output_styling+"_output_tracks.tck",
+						mask_bin_mask=results.whitematter_mask)
+	print(tck_out)
+
+	connectomegen = function("tck2connectome_desc.json")
+	connectome_out = connectomegen(input_nodes=results.nodes,
+									input_tracks=results.output_styling+"_output_tracks.tck",
+									output_connectome=results.output_styling+"_output_connectome.csv")
+	print(connectome_out)
+
+main()

--- a/code/tractography/mrtrix/tck2connectome_desc.json
+++ b/code/tractography/mrtrix/tck2connectome_desc.json
@@ -1,0 +1,132 @@
+{
+    "author": "Édouard Théroux",
+    "command-line": "tck2connectome [INFO] [QUIET] [DEBUG] [FORCE] [NTHREADS] [HELP] [VERSION] [INPUT_TRACKS] [INPUT_NODES] [OUTPUT_CONNECTOME]",
+    "container-image": {
+        "image": "darrinfong/mrtrix3:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "name": "tck2connectome Connectome generator",
+    "description": "Generate a connectome matrix from a streamlines file and a node parcellation image",
+    "inputs": [
+        {
+            "command-line-flag": "-info",
+            "description": "Display information messages.",
+            "id": "info",
+            "name": "info",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[INFO]",
+            "disables-inputs": ["quiet", "debug"]
+        },
+        {
+            "command-line-flag": "-quiet",
+            "description": "Do not display information messages or progress status.",
+            "id": "quiet",
+            "name": "quiet",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[QUIET]",
+            "disables-inputs": ["info", "debug"]
+        },
+        {
+            "command-line-flag": "-debug",
+            "description": "Display debugging messages.",
+            "id": "debug",
+            "name": "debug",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DEBUG]",
+            "disables-inputs": ["info", "quiet"]
+        },
+        {
+            "command-line-flag": "-force",
+            "description": "Force overwrite of output files. Caution: Using the same file as input and output might cause unexpected behaviour.",
+            "id": "force",
+            "name": "force",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FORCE]"
+        },
+        {
+            "command-line-flag": "-nthreads",
+            "description": "Use this number of threads in multi-threaded applications (set to 0 to disable multi-threading)",
+            "id": "nthreads",
+            "name": "nthreads",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[NTHREADS]"
+        },
+        {
+            "command-line-flag": "-help",
+            "description": "Display this information page and exit",
+            "id": "help",
+            "name": "help",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HELP]"
+        },
+        {
+            "command-line-flag": "-version",
+            "description": "Display version information and exit",
+            "id": "version",
+            "name": "version",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[VERSION]"
+        },
+        {
+            "description": "The input track file",
+            "id": "input_tracks",
+            "name": "input_tracks",
+            "optional": false,
+            "type": "File",
+            "value-key": "[INPUT_TRACKS]"
+        },
+        {
+            "description": "The input node parcellation image",
+            "id": "input_nodes",
+            "name": "input_nodes",
+            "optional": false,
+            "type": "File",
+            "value-key": "[INPUT_NODES]"
+        },
+        {
+            "description": "The output .csv file containing edge weights",
+            "id": "output_connectome",
+            "name": "output_connectome",
+            "optional": false,
+            "type": "String",
+            "value-key": "[OUTPUT_CONNECTOME]"
+        }
+    ],
+    "output-files": [
+        {
+            "id": "output_csv",
+            "name": "Output connectome csv file",
+            "description": "The connectome file output",
+            "optional": false,
+            "path-template": "[OUTPUT_CONNECTOME].csv",
+            "path-template-stripped-extensions": [
+                ".csv"
+            ]
+        }
+    ],
+    "schema-version": "0.5",
+    "suggested-resources": {
+        "cpu-cores": 1,
+        "ram": 2048,
+        "walltime-estimate": 20
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "image processing",
+            "mri",
+            "dwi",
+            "tractography"
+        ]
+    },
+    "tool-version": "v0.1.0"
+}

--- a/code/tractography/mrtrix/tckedit_desc.json
+++ b/code/tractography/mrtrix/tckedit_desc.json
@@ -1,6 +1,6 @@
 {
     "author": "Darrin Fong",
-    "command-line": "tsckedit [INCLUDE_BIN_MASK] [INCLUDE_SPHERE] [EXCLUDE_BIN_MASK] [EXCLUDE_SPHERE] [MASK_BIN_MASK] [MASK_SPHERE] [MAXLENGTH] [MINLENGTH] [NUMBER] [SKIP] [MAXWEIGHT] [MINWEIGHT] [INVERSE] [ENDS_ONLY] [TCK_WEIGHTS_IN] [TCK_WEIGHTS_OUT] [INFO] [QUIET] [DEBUG] [FORCE] [NTHREADS] [HELP] [VERSION] [TRACKS_IN] [TRACKS_OUT]",
+    "command-line": "tckedit [INCLUDE_BIN_MASK] [INCLUDE_SPHERE] [EXCLUDE_BIN_MASK] [EXCLUDE_SPHERE] [MASK_BIN_MASK] [MASK_SPHERE] [MAXLENGTH] [MINLENGTH] [NUMBER] [SKIP] [MAXWEIGHT] [MINWEIGHT] [INVERSE] [ENDS_ONLY] [TCK_WEIGHTS_IN] [TCK_WEIGHTS_OUT] [INFO] [QUIET] [DEBUG] [FORCE] [NTHREADS] [HELP] [VERSION] [TRACKS_IN] [TRACKS_OUT]",
     "container-image": {
         "image": "darrinfong/mrtrix3:latest",
         "index": "index.docker.io",
@@ -257,11 +257,11 @@
             "name": "Output track file",
             "description": "The output track file",
             "optional": false,
-            "path-template": "[TRACKS_OUT].trk",
+            "path-template": "[TRACKS_OUT].tck",
             "path-template-stripped-extensions": [
                 ".nii.gz",
                 ".nii",
-                ".json"
+                ".tck"
             ]
         },
         {
@@ -271,9 +271,7 @@
             "optional": true,
             "path-template": "[TCK_WEIGHTS_OUT].txt",
             "path-template-stripped-extensions": [
-                ".nii.gz",
-                ".nii",
-                ".json"
+                ".txt"
             ]
         }
     ],

--- a/code/tractography/mrtrix/tckedit_desc.json
+++ b/code/tractography/mrtrix/tckedit_desc.json
@@ -1,0 +1,296 @@
+{
+    "author": "Darrin Fong",
+    "command-line": "tsckedit [INCLUDE_BIN_MASK] [INCLUDE_SPHERE] [EXCLUDE_BIN_MASK] [EXCLUDE_SPHERE] [MASK_BIN_MASK] [MASK_SPHERE] [MAXLENGTH] [MINLENGTH] [NUMBER] [SKIP] [MAXWEIGHT] [MINWEIGHT] [INVERSE] [ENDS_ONLY] [TCK_WEIGHTS_IN] [TCK_WEIGHTS_OUT] [INFO] [QUIET] [DEBUG] [FORCE] [NTHREADS] [HELP] [VERSION] [TRACKS_IN] [TRACKS_OUT]",
+    "container-image": {
+        "image": "darrinfong/mrtrix3:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "name": "tckedit Track editor",
+    "description": "Perform various editing operations on track files.",
+    "inputs": [
+        {
+            "command-line-flag": "-include",
+            "description": "Specify an inclusion region of interest, as either a binary mask image. Streamlines must traverse ALL inclusion regions to be accepted.",
+            "id": "include_bin_mask",
+            "name": "include binary mask region",
+            "optional": true,
+            "type": "File",
+            "disables-inputs": ["include_sphere"],
+            "value-key": "[INCLUDE_BIN_MASK]"
+        },
+        {
+            "command-line-flag": "-include",
+            "description": "Specify an inclusion region of interest, as a sphere using 4 comma-separared values (x,y,z,radius). Streamlines must traverse ALL inclusion regions to be accepted.",
+            "id": "include_sphere",
+            "name": "include sphere region",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "disables-inputs": ["include_bin_mask"],
+            "value-key": "[INCLUDE_SPHERE]"
+        },
+        {
+            "command-line-flag": "-exclude",
+            "description": "Specify an exclusion region of interest, as either a binary mask image. Streamlines that enter ANY exclude region will be discarded.",
+            "id": "exclude_bin_mask",
+            "name": "exclude binary mask region",
+            "optional": true,
+            "type": "File",
+            "disables-inputs": ["exclude_sphere"],
+            "value-key": "[EXCLUDE_BIN_MASK]"
+        },
+        {
+            "command-line-flag": "-exclude",
+            "description": "Specify an exclusion region of interest, as a sphere using 4 comma-separared values (x,y,z,radius). Streamlines that enter ANY exclude region will be discarded.",
+            "id": "exclude_sphere",
+            "name": "exclude sphere region",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "disables-inputs": ["exclude_bin_mask"],
+            "value-key": "[EXCLUDE_SPHERE]"
+        },
+        {
+            "command-line-flag": "-mask",
+            "description": "Specify a masking region of interest, as either a binary mask image. If defined, streamlines exiting the mask will be truncated.",
+            "id": "mask_bin_mask",
+            "name": "mask binary mask region",
+            "optional": true,
+            "type": "File",
+            "disables-inputs": ["mask_sphere"],
+            "value-key": "[MASK_BIN_MASK]"
+        },
+        {
+            "command-line-flag": "-mask",
+            "description": "Specify a masking region of interest, as a sphere using 4 comma-separared values (x,y,z,radius). If defined, streamlines exiting the mask will be truncated.",
+            "id": "mask_sphere",
+            "name": "mask sphere region",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "disables-inputs": ["mask_bin_mask"],
+            "value-key": "[MASK_SPHERE]"
+        },
+        {
+            "command-line-flag": "-maxlength",
+            "description": "Set the maximum length of any streamline in mm",
+            "id": "maxlength",
+            "name": "maxlength",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[MAXLENGTH]"
+        },
+        {
+            "command-line-flag": "-minlength",
+            "description": "Set the minimum length of any streamline in mm",
+            "id": "minlength",
+            "name": "minlength",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[MINLENGTH]"
+        },
+        {
+            "command-line-flag": "-number",
+            "description": "Set the desired number of selected streamlines to be propagated to the output file",
+            "id": "number",
+            "name": "number",
+            "optional": true,
+            "integer":true,
+            "type": "Number",
+            "value-key": "[NUMBER]"
+        },
+        {
+            "command-line-flag": "-skip",
+            "description": "Omit this number of selected streamlines before commencing writing to the output file",
+            "id": "skip",
+            "name": "skip",
+            "optional": true,
+            "integer":true,
+            "type": "Number",
+            "value-key": "[SKIP]"
+        },
+        {
+            "command-line-flag": "-maxweight",
+            "description": "Set the maximum weight of any streamline",
+            "id": "maxweight",
+            "name": "maxweight",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[MAXWEIGHT]"
+        },
+        {
+            "command-line-flag": "-minweight",
+            "description": "Set the minimum weight of any streamline",
+            "id": "minweight",
+            "name": "minweight",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[MINWEIGHT]"
+        },
+        {
+            "command-line-flag": "-inverse",
+            "description": "Output the inverse selection of streamlines based on the criteria provided, i.e. only those streamlines that fail at least one criterion will be written to file.",
+            "id": "inverse",
+            "name": "inverse",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[INVERSE]"
+        },
+        {
+            "command-line-flag": "-ends_only",
+            "description": "Only test the ends of each streamline against the provided include/exclude ROIs",
+            "id": "ends_only",
+            "name": "Ends only",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[ENDS_ONLY]"
+        },
+        {
+            "command-line-flag": "-tck_weights_in",
+            "description": "Specify a text scalar file containing the streamline weights",
+            "id": "tck_weights_in",
+            "name": "tck_weights_in",
+            "optional": true,
+            "type": "File",
+            "value-key": "[TCK_WEIGHTS_IN]"
+        },
+        {
+            "command-line-flag": "-tck_weights_out",
+            "description": "Specify the path for an output text scalar file containing streamline weights",
+            "id": "tck_weights_out",
+            "name": "tck_weights_out",
+            "optional": true,
+            "type": "String",
+            "value-key": "[TCK_WEIGHTS_OUT]"
+        },
+        {
+            "command-line-flag": "-info",
+            "description": "Display information messages.",
+            "id": "info",
+            "name": "info",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[INFO]",
+            "disables-inputs": ["quiet", "debug"]
+        },
+        {
+            "command-line-flag": "-quiet",
+            "description": "Do not display information messages or progress status.",
+            "id": "quiet",
+            "name": "quiet",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[QUIET]",
+            "disables-inputs": ["info", "debug"]
+        },
+        {
+            "command-line-flag": "-debug",
+            "description": "Display debugging messages.",
+            "id": "debug",
+            "name": "debug",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DEBUG]",
+            "disables-inputs": ["info", "quiet"]
+        },
+        {
+            "command-line-flag": "-force",
+            "description": "Force overwrite of output files. Caution: Using the same file as input and output might cause unexpected behaviour.",
+            "id": "force",
+            "name": "force",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FORCE]"
+        },
+        {
+            "command-line-flag": "-nthreads",
+            "description": "Use this number of threads in multi-threaded applications (set to 0 to disable multi-threading)",
+            "id": "nthreads",
+            "name": "nthreads",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[NTHREADS]"
+        },
+        {
+            "command-line-flag": "-help",
+            "description": "Display this information page and exit",
+            "id": "help",
+            "name": "help",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HELP]"
+        },
+        {
+            "command-line-flag": "-version",
+            "description": "Display version information and exit",
+            "id": "version",
+            "name": "version",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[VERSION]"
+        },
+        {
+            "description": "The input track file(s)",
+            "id": "tracks_in",
+            "name": "tracks_in",
+            "optional": false,
+            "list": true,
+            "type": "File",
+            "value-key": "[TRACKS_IN]"
+        },
+        {
+            "description": "The output track file",
+            "id": "tracks_out",
+            "name": "tracks_out",
+            "optional": false,
+            "type": "String",
+            "value-key": "[TRACKS_OUT]"
+        }
+    ],
+    "output-files": [
+        {
+            "id": "track_output",
+            "name": "Output track file",
+            "description": "The output track file",
+            "optional": false,
+            "path-template": "[TRACKS_OUT].trk",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii",
+                ".json"
+            ]
+        },
+        {
+            "id": "weights_output",
+            "name": "Streamline weights output",
+            "description": "Text scalar file containing streamline weights",
+            "optional": true,
+            "path-template": "[TCK_WEIGHTS_OUT].txt",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii",
+                ".json"
+            ]
+        }
+    ],
+    "schema-version": "0.5",
+    "suggested-resources": {
+        "cpu-cores": 1,
+        "ram": 2048,
+        "walltime-estimate": 20
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "image processing",
+            "mri",
+            "dwi",
+            "tractography"
+        ]
+    },
+    "tool-version": "v0.1.0"
+}

--- a/code/tractography/mrtrix/tckgen_desc.json
+++ b/code/tractography/mrtrix/tckgen_desc.json
@@ -1,0 +1,546 @@
+{
+    "author": "Darrin Fong",
+    "command-line": "tckgen [ALGORITHM] [SELECT] [STEP_DEFAULT] [ANGLE] [MINLENGTH] [MAXLENGTH] [CUTOFF_FOD] [TRIALS] [NOPRECOMPUTED] [RK4] [STOP] [DOWNSAMPLE] [SEED_IMAGE] [SEED_SPHERE] [SEED_RANDOM_PER_VOXEL] [NUM_PER_VOXEL] [SEED_GRID_PER_VOXEL] [GRID_SIZE] [SEED_REJECTION] [SEED_GMWMI] [SEED_DYNAMIC] [SEEDS] [MAX_ATTEMPTS_PER_SEED] [SEED_CUTOFF] [SEED_UNIDIRECTIONAL] [SEED_DIRECTION] [OUTPUT_SEEDS] [INCLUDE_BIN_MASK] [EXCLUDE_BIN_MASK] [MASK_BIN_MASK] [ACT] [BACKTRACK] [CROP_AT_GMWMI] [SAMPLES] [POWER] [GRAD] [FSLGRAD] [BVECS] [BVALS] [BVALUE_SCALING] [INFO] [QUIET] [DEBUG] [FORCE] [NTHREADS] [HELP] [VERSION] [SOURCE] [TRACKS]",
+    "container-image": {
+        "image": "darrinfong/mrtrix3:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "name": "tckgen Streamlines tractography",
+    "description": "Perform streamlines tractography.",
+    "inputs": [
+        {
+            "command-line-flag": "-algorithm",
+            "description": "Specify the tractography algorithm to use. Valid choices are: FACT, iFOD1, iFOD2, Nulldist1, Nulldist2, SD_Stream, Seedtest, Tensor_Det, Tensor_Prob (default: iFOD2).",
+            "id": "algorithm",
+            "name": "algorithm",
+            "optional": true,
+            "value-choices": ["FACT", "iFOD1", "iFOD2", "Nulldist1", "Nulldist2", "SD_Stream", "Seedtest", "Tensor_Det", "Tensor_Prob"],
+            "type": "String",
+            "default-value": "iFOD2",
+            "value-disables": {
+                "FACT": ["samples", "power", "cutoff_FOD"],
+                "iFOD1": ["samples", "power"],
+                "iFOD2": ["step_default", "downsample"],
+                "Nulldist1": ["samples", "power", "cutoff_FOD"],
+                "Nulldist2": ["samples", "power", "cutoff_FOD"],
+                "SD_Stream": ["samples", "power"],
+                "Seedtest": ["samples", "power", "cutoff_FOD"],
+                "Tensor_Det": ["samples", "power", "cutoff_FOD"],
+                "Tensor_Prob": ["samples", "power",  "cutoff_FOD"]
+            },
+            "value-key": "[ALGORITHM]"
+        },
+        {
+            "command-line-flag": "-select",
+            "description": "Set the desired number of streamlines to be selected by tckgen, after all selection criteria have been applied (i.e. inclusion/exclusion ROIs, min/max length, etc). tckgen will keep seeding streamlines until this number of streamlines have been selected, or the maximum allowed number of seeds has been exceeded (see -seeds option). By default, 5000 streamlines are to be selected. Set to zero to disable, which will result in streamlines being seeded until the number specified by -seeds has been reached.",
+            "id": "select",
+            "name": "select",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "minimum": 0,
+            "default-value": 5000,
+            "value-key": "[SELECT]"
+        },
+        {
+            "command-line-flag": "-step",
+            "description": "Set the step size of the algorithm in mm (default is 0.1 x voxelsize).",
+            "id": "step_default",
+            "name": "Default step",
+            "optional": true,
+            "type": "Number",
+            "default-value": 0.1,
+            "value-key": "[STEP_DEFAULT]"
+        },
+        {
+            "command-line-flag": "-angle",
+            "description": "Set the maximum angle between successive steps (default is 90deg x stepsize / voxelsize).",
+            "id": "angle",
+            "name": "angle",
+            "optional": true,
+            "type": "Number",
+            "default-value": 90,
+            "value-key": "[ANGLE]"
+        },
+        {
+            "command-line-flag": "-minlength",
+            "description": "Set the minimum length of any track in mm (default is 2 x voxelsize with ACT).",
+            "id": "minlength_with_ACT",
+            "name": "minlength with ACT",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "default-value": 2,
+            "value-key": "[MINLENGTH]"
+        },
+        {
+            "command-line-flag": "-maxlength",
+            "description": "Set the maximum length of any track in mm (default is 100 x voxelsize).",
+            "id": "maxlength",
+            "name": "maxlength",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "default-value": 100,
+            "value-key": "[MAXLENGTH]"
+        },
+        {
+            "command-line-flag": "-cutoff",
+            "description": "Set the FOD amplitude / fixel size / tensor FA cutoff for terminating tracks (defaults are: 0.05 for FOD-based algorithms; 0.05 for fixel-based algorithms; 0.1 for tensor-based algorithms).",
+            "id": "cutoff_FOD",
+            "name": "FOD cutoff",
+            "optional": true,
+            "type": "Number",
+            "default-value": 0.05,
+            "value-key": "[CUTOFF_FOD]"
+        },
+        {
+            "command-line-flag": "-trials",
+            "description": "Set the maximum number of sampling trials at each point (only used for probabilistic tracking).",
+            "id": "trials",
+            "name": "trials",
+            "optional": true,
+            "integer":true,
+            "type": "Number",
+            "value-key": "[TRIALS]"
+        },
+        {
+            "command-line-flag": "-noprecomputed",
+            "description": "Do NOT pre-compute legendre polynomial values. Warning: this will slow down the algorithm by a factor of approximately 4.",
+            "id": "noprecomputed",
+            "name": "noprecomputed",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[NOPRECOMPUTED]"
+        },
+        {
+            "command-line-flag": "-rk4",
+            "description": "Use 4th-order Runge-Kutta integration (slower, but eliminates curvature overshoot in 1st-order deterministic methods)",
+            "id": "rk4",
+            "name": "rk4",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[RK4]"
+        },
+        {
+            "command-line-flag": "-stop",
+            "description": "Stop propagating a streamline once it has traversed all include regions",
+            "id": "stop",
+            "name": "stop",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[STOP]"
+        },
+        {
+            "command-line-flag": "-downsample",
+            "description": "Downsample the generated streamlines to reduce output file size (default is no downsampling, except iFOD2)",
+            "id": "downsample",
+            "name": "downsample",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[DOWNSAMPLE]"
+        },
+        {
+            "command-line-flag": "-seed_image",
+            "description": "Seed streamlines entirely at random within a mask image",
+            "id": "seed_image",
+            "name": "seed_image",
+            "optional": true,
+            "type": "File",
+            "disables-inputs": ["seed_dynamic"],
+            "value-key": "[SEED_IMAGE]"
+        },
+        {
+            "command-line-flag": "-seed_sphere",
+            "description": "Spherical seed as four comma-separated values (XYZ position and radius)",
+            "id": "seed_sphere",
+            "name": "seed_sphere",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "disables-inputs": ["seed_dynamic"],
+            "value-key": "[SEED_SPHERE]"
+        },
+        {
+            "command-line-flag": "-seed_random_per_voxel",
+            "description": "Seed a fixed number of streamlines per voxel in a mask image; random placement of seeds in each voxel",
+            "id": "seed_random_per_voxel",
+            "name": "seed_random_per_voxel",
+            "optional": true,
+            "type": "File",
+            "requires-inputs": ["num_per_voxel"],
+            "disables-inputs": ["seed_dynamic"],
+            "value-key": "[SEED_RANDOM_PER_VOXEL]"
+        },
+        {
+            "description": "Seed a fixed number of streamlines per voxel in a mask image; random placement of seeds in each voxel",
+            "id": "num_per_voxel",
+            "name": "Streamlines number per voxel",
+            "optional": true,
+            "type": "Number",
+            "requires-inputs": ["seed_random_per_voxel"],
+            "disables-inputs": ["seed_dynamic"],
+            "value-key": "[NUM_PER_VOXEL]"
+        },
+        {
+            "command-line-flag": "-seed_grid_per_voxel",
+            "description": "Seed a fixed number of streamlines per voxel in a mask image; place seeds on a 3D mesh grid (grid_size argument is per axis; so a grid_size of 3 results in 27 seeds per voxel)",
+            "id": "seed_grid_per_voxel",
+            "name": "seed_grid_per_voxel",
+            "optional": true,
+            "type": "File",
+            "requires-inputs": ["grid_size"],
+            "disables-inputs": ["seed_dynamic"],
+            "value-key": "[SEED_GRID_PER_VOXEL]"
+        },
+        {
+            "description": "Seed a fixed number of streamlines per voxel in a mask image; place seeds on a 3D mesh grid (grid_size argument is per axis; so a grid_size of 3 results in 27 seeds per voxel)",
+            "id": "grid_size",
+            "name": "3D Seeds mesh grid",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "requires-inputs": ["seed_grid_per_voxel"],
+            "disables-inputs": ["seed_dynamic"],
+            "value-key": "[GRID_SIZE]"
+        },
+        {
+            "command-line-flag": "-seed_rejection",
+            "description": "Seed from an image using rejection sampling (higher values = more probable to seed from)",
+            "id": "seed_rejection",
+            "name": "seed_rejection",
+            "optional": true,
+            "type": "File",
+            "disables-inputs": ["seed_dynamic"],
+            "value-key": "[SEED_REJECTION]"
+        },
+        {
+            "command-line-flag": "-seed_gmwmi",
+            "description": "Seed from the grey matter - white matter interface (only valid if using ACT framework). Input image should be a 3D seeding volume; seeds drawn within this image will be optimised to the interface using the 5TT image provided using the -act option.",
+            "id": "seed_gmwmi",
+            "name": "seed_gmwmi",
+            "optional": true,
+            "type": "File",
+            "requires-inputs": ["act"],
+            "disables-inputs": ["seed_dynamic"],
+            "value-key": "[SEED_GMWMI]"
+        },
+        {
+            "command-line-flag": "-seed_dynamic",
+            "description": "Ddetermine seed points dynamically using the SIFT model (must not provide any other seeding mechanism). Note that while this seeding mechanism improves the distribution of reconstructed streamlines density, it should NOT be used as a substitute for the SIFT method itself.",
+            "id": "seed_dynamic",
+            "name": "seed_dynamic",
+            "optional": true,
+            "type": "File",
+            "disables-inputs": ["seed_sphere", "seed_image", "seed_random_per_voxel", "seed_grid_per_voxel", "seed_rejection", "seed_gmwmi"],
+            "value-key": "[SEED_DYNAMIC]"
+        },
+        {
+            "command-line-flag": "-seeds",
+            "description": "Set the number of seeds that tckgen will attempt to track from. If this option is NOT provided, the default number of seeds is set to 1000× the number of selected streamlines. If -select is NOT also specified, tckgen will continue tracking until this number of seeds has been attempted. However, if -select is also specified, tckgen will stop when the number of seeds attempted reaches the number specified here, OR when the number of streamlines selected reaches the number requested with the -select option. This can be used to prevent the program from running indefinitely when no or very few streamlines can be found that match the selection criteria. Setting this to zero will cause tckgen to keep attempting seeds until the number specified by -select has been reached.",
+            "id": "seeds",
+            "name": "seeds",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "minimum": 0,
+            "value-key": "[SEEDS]"
+        },
+        {
+            "command-line-flag": "-max_attempts_per_seed",
+            "description": "Set the maximum number of times that the tracking algorithm should attempt to find an appropriate tracking direction from a given seed point. This should be set high enough to ensure that an actual plausible seed point is not discarded prematurely as being unable to initiate tracking from. Higher settings may affect performance if many seeds are genuinely impossible to track from, as many attempts will still be made in vain for such seeds. (default: 1000)",
+            "id": "max_attempts_per_seed",
+            "name": "Maximum attempts per seed",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "default-value": 1000,
+            "value-key": "[MAX_ATTEMPTS_PER_SEED]"
+        },
+        {
+            "command-line-flag": "-seed_cutoff",
+            "description": "Set the minimum FA or FOD amplitude for seeding tracks (default is the same as the normal -cutoff).",
+            "id": "seed_cutoff",
+            "name": "Seed cutoff",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[SEED_CUTOFF]"
+        },
+        {
+            "command-line-flag": "-seed_unidirectional",
+            "description": "Track from the seed point in one direction only (default is to track in both directions).",
+            "id": "seed_unidirectional",
+            "name": "Seed unidirectionally",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[SEED_UNIDIRECTIONAL]"
+        },
+        {
+            "command-line-flag": "-seed_direction",
+            "description": "Specify a seeding direction for the tracking (this should be supplied as a vector of 3 comma-separated values.",
+            "id": "seed_direction",
+            "name": "Seed direction",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "value-key": "[SEED_DIRECTION]"
+        },
+        {
+            "command-line-flag": "-output_seeds",
+            "description": "Output the seed location of all successful streamlines to a file",
+            "id": "output_seeds",
+            "name": "output_seeds",
+            "optional": true,
+            "type": "String",
+            "value-key": "[OUTPUT_SEEDS]"
+        },
+        {
+            "command-line-flag": "-include",
+            "description": "Specify an inclusion region of interest, as either a binary mask image. Streamlines must traverse ALL inclusion regions to be accepted.",
+            "id": "include_bin_mask",
+            "name": "include binary mask region",
+            "optional": true,
+            "type": "File",
+            "value-key": "[INCLUDE_BIN_MASK]"
+        },
+        {
+            "command-line-flag": "-exclude",
+            "description": "Specify an exclusion region of interest, as either a binary mask image. Streamlines that enter ANY exclude region will be discarded.",
+            "id": "exclude_bin_mask",
+            "name": "exclude binary mask region",
+            "optional": true,
+            "type": "File",
+            "value-key": "[EXCLUDE_BIN_MASK]"
+        },
+        {
+            "command-line-flag": "-mask",
+            "description": "Specify a masking region of interest, as either a binary mask image. If defined, streamlines exiting the mask will be truncated.",
+            "id": "mask_bin_mask",
+            "name": "mask binary mask region",
+            "optional": true,
+            "type": "File",
+            "value-key": "[MASK_BIN_MASK]"
+        },
+        {
+            "command-line-flag": "-act",
+            "description": "Use the Anatomically-Constrained Tractography framework during tracking; provided image must be in the 5TT (five-tissue-type) format",
+            "id": "act",
+            "name": "act",
+            "optional": true,
+            "type": "File",
+            "value-key": "[ACT]"
+        },
+        {
+            "command-line-flag": "-backtrack",
+            "description": "Allow tracks to be truncated and re-tracked if a poor structural termination is encountered",
+            "id": "backtrack",
+            "name": "backtrack",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[BACKTRACK]"
+        },
+        {
+            "command-line-flag": "-crop_at_gmwmi",
+            "description": "Crop streamline endpoints more precisely as they cross the GM-WM interface",
+            "id": "crop_at_gmwmi",
+            "name": "crop_at_gmwmi",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[CROP_AT_GMWMI]"
+        },
+        {
+            "command-line-flag": "-samples",
+            "description": "Set the number of FOD samples to take per step (Default: 4)",
+            "id": "samples",
+            "name": "samples",
+            "optional": true,
+            "integer":true,
+            "type": "Number",
+            "default-value": 4,
+            "value-key": "[SAMPLES]"
+        },
+        {
+            "command-line-flag": "-power",
+            "description": "Raise the FOD to the power specified (default is 1/nsamples).",
+            "id": "power",
+            "name": "power",
+            "optional": true,
+            "type": "Number",
+            "default-value": 1,
+            "value-key": "[POWER]"
+        },
+        {
+            "command-line-flag": "-grad",
+            "description": "Provide the diffusion-weighted gradient scheme used in the acquisition in a text file. This should be supplied as a 4xN text file with each line is in the format [ X Y Z b ], where [ X Y Z ] describe the direction of the applied gradient, and b gives the b-value in units of s/mm^2. If a diffusion gradient scheme is present in the input image header, the data provided with this option will be instead used.",
+            "id": "grad",
+            "name": "grad",
+            "optional": true,
+            "type": "File",
+            "value-key": "[GRAD]"
+        },
+        {
+            "command-line-flag": "-fslgrad",
+            "description": "Provide the diffusion-weighted gradient scheme used in the acquisition in FSL bvecs/bvals format files. If a diffusion gradient scheme is present in the input image header, the data provided with this option will be instead used.",
+            "id": "fslgrad",
+            "name": "fslgrad",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FSLGRAD]",
+            "requires-inputs": ["bvecs", "bvals"]
+        },
+        {
+            "description": "Specify the diffusion-weighted gradient scheme used in the acquisition in FSL bvecs format.",
+            "id": "bvecs",
+            "name": "bvecs",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVECS]",
+            "requires-inputs": ["fslgrad", "bvals"]
+        },
+        {
+            "description": "Specify the diffusion-weighted gradient scheme used in the acquisition in FSL bvals format.",
+            "id": "bvals",
+            "name": "bvals",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVALS]",
+            "requires-inputs": ["fslgrad", "bvecs"]
+        },
+        {
+            "command-line-flag": "-bvalue_scaling",
+            "description": "Specifies whether the b-values should be scaled by the square of the corresponding DW gradient norm, as often required for multi-shell or DSI DW acquisition schemes. The default action can also be set in the MRtrix config file, under the BValueScaling entry. Valid choices are yes/no, true/false, 0/1 (default: true).",
+            "id": "bvalue_scaling",
+            "name": "bvalue_scaling",
+            "optional": true,
+            "type": "String",
+            "value-key": "[BVALUE_SCALING]",
+            "value-choices": ["yes", "no", "true", "false", "0", "1"],
+            "default-value": "true"
+        },
+        {
+            "command-line-flag": "-info",
+            "description": "Display information messages.",
+            "id": "info",
+            "name": "info",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[INFO]",
+            "disables-inputs": ["quiet", "debug"]
+        },
+        {
+            "command-line-flag": "-quiet",
+            "description": "Do not display information messages or progress status.",
+            "id": "quiet",
+            "name": "quiet",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[QUIET]",
+            "disables-inputs": ["info", "debug"]
+        },
+        {
+            "command-line-flag": "-debug",
+            "description": "Display debugging messages.",
+            "id": "debug",
+            "name": "debug",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DEBUG]",
+            "disables-inputs": ["info", "quiet"]
+        },
+        {
+            "command-line-flag": "-force",
+            "description": "Force overwrite of output files. Caution: Using the same file as input and output might cause unexpected behaviour.",
+            "id": "force",
+            "name": "force",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FORCE]"
+        },
+        {
+            "command-line-flag": "-nthreads",
+            "description": "Use this number of threads in multi-threaded applications (set to 0 to disable multi-threading)",
+            "id": "nthreads",
+            "name": "nthreads",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[NTHREADS]"
+        },
+        {
+            "command-line-flag": "-help",
+            "description": "Display this information page and exit",
+            "id": "help",
+            "name": "help",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HELP]"
+        },
+        {
+            "command-line-flag": "-version",
+            "description": "Display version information and exit",
+            "id": "version",
+            "name": "version",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[VERSION]"
+        },
+        {
+            "description": "The image containing the source data. The type of image data required depends on the algorithm used (see Description section).",
+            "id": "source",
+            "name": "source",
+            "optional": false,
+            "type": "File",
+            "value-key": "[SOURCE]"
+        },
+        {
+            "description": "The output file containing the tracks generated.",
+            "id": "tracks",
+            "name": "Tracks generated",
+            "optional": false,
+            "type": "String",
+            "value-key": "[TRACKS]"
+        }
+    ],
+    "output-files": [
+        {
+            "id": "tracks_output",
+            "name": "Tracks output",
+            "description": "The output file containing the tracks generated.",
+            "optional": false,
+            "path-template": "[TRACKS].tck",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii",
+                ".tck"
+            ]
+        },
+        {
+            "id": "Seed_location",
+            "name": "Seed location",
+            "description": "Seed location of all successful streamlines",
+            "optional": true,
+            "path-template": "[OUTPUT_SEEDS].txt",
+            "path-template-stripped-extensions": [
+                ".txt"
+            ]
+        }
+    ],
+    "schema-version": "0.5",
+    "suggested-resources": {
+        "cpu-cores": 1,
+        "ram": 2048,
+        "walltime-estimate": 20
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "image processing",
+            "mri",
+            "dwi",
+            "tractography"
+        ]
+    },
+    "tool-version": "v0.1.0"
+}

--- a/code/tractography/mrtrix/tckgen_desc.json
+++ b/code/tractography/mrtrix/tckgen_desc.json
@@ -1,10 +1,6 @@
 {
     "author": "Darrin Fong",
-<<<<<<< HEAD
-    "command-line": "tckgen [ALGORITHM] [SELECT] [STEP_DEFAULT] [STEP_IFOD2] [ANGLE] [MINLENGTH] [MINLENGTH_WITH_ACT] [MAXLENGTH] [CUTOFF_FOD] [CUTOFF_FIXEL] [CUTOFF_TENSOR] [TRIALS] [NOPRECOMPUTED] [RK4] [STOP] [DOWNSAMPLE] [DOWNSAMPLE_IFOD2] [SEED_IMAGE] [SEED_SPHERE] [SEED_RANDOM_PER_VOXEL] [NUM_PER_VOXEL] [SEED_GRID_PER_VOXEL] [GRID_SIZE] [SEED_REJECTION] [SEED_GMWMI] [SEED_DYNAMIC] [SEEDS] [MAX_ATTEMPTS_PER_SEED] [SEED_CUTOFF] [SEED_UNIDIRECTIONAL] [SEED_DIRECTION] [OUTPUT_SEEDS] [INCLUDE_BIN_MASK] [INCLUDE_SPHERE] [EXCLUDE_BIN_MASK] [EXCLUDE_SPHERE] [MASK_BIN_MASK] [MASK_SPHERE] [ACT] [BACKTRACK] [CROP_AT_GMWMI] [SAMPLES] [POWER] [GRAD] [FSLGRAD] [BVECS] [BVALS] [BVALUE_SCALING] [INFO] [QUIET] [DEBUG] [FORCE] [NTHREADS] [HELP] [VERSION] [SOURCE] [TRACKS]",
-=======
     "command-line": "tckgen [ALGORITHM] [SELECT] [STEP_DEFAULT] [ANGLE] [MINLENGTH] [MAXLENGTH] [CUTOFF_FOD] [TRIALS] [NOPRECOMPUTED] [RK4] [STOP] [DOWNSAMPLE] [SEED_IMAGE] [SEED_SPHERE] [SEED_RANDOM_PER_VOXEL] [NUM_PER_VOXEL] [SEED_GRID_PER_VOXEL] [GRID_SIZE] [SEED_REJECTION] [SEED_GMWMI] [SEED_DYNAMIC] [SEEDS] [MAX_ATTEMPTS_PER_SEED] [SEED_CUTOFF] [SEED_UNIDIRECTIONAL] [SEED_DIRECTION] [OUTPUT_SEEDS] [INCLUDE_BIN_MASK] [EXCLUDE_BIN_MASK] [MASK_BIN_MASK] [ACT] [BACKTRACK] [CROP_AT_GMWMI] [SAMPLES] [POWER] [GRAD] [FSLGRAD] [BVECS] [BVALS] [BVALUE_SCALING] [INFO] [QUIET] [DEBUG] [FORCE] [NTHREADS] [HELP] [VERSION] [SOURCE] [TRACKS]",
->>>>>>> 4a34f65c4b251e80202c9063954376fc34e91b46
     "container-image": {
         "image": "darrinfong/mrtrix3:latest",
         "index": "index.docker.io",
@@ -55,27 +51,9 @@
             "optional": true,
             "type": "Number",
             "default-value": 0.1,
-<<<<<<< HEAD
-            "disables-inputs": ["step_iFOD2"],
             "value-key": "[STEP_DEFAULT]"
         },
         {
-            "command-line-flag": "-step",
-            "description": "Set the step size of the algorithm in mm (default for iFOD2: 0.5 x voxelsize).",
-            "id": "step_iFOD2",
-            "name": "iFOD2 step",
-            "optional": true,
-            "type": "Number",
-            "default-value": 0.5,
-            "disables-inputs": ["step_default"],
-            "value-key": "[STEP_IFOD2]"
-        },
-        {
-=======
-            "value-key": "[STEP_DEFAULT]"
-        },
-        {
->>>>>>> 4a34f65c4b251e80202c9063954376fc34e91b46
             "command-line-flag": "-angle",
             "description": "Set the maximum angle between successive steps (default is 90deg x stepsize / voxelsize).",
             "id": "angle",
@@ -94,29 +72,9 @@
             "integer": true,
             "type": "Number",
             "default-value": 2,
-<<<<<<< HEAD
-            "disables-inputs": ["minlength"],
-            "requires-inputs": ["act"],
             "value-key": "[MINLENGTH]"
         },
         {
-            "command-line-flag": "-minlength",
-            "description": "Set the minimum length of any track in mm (default is 5 x voxelsize without ACT).",
-            "id": "minlength",
-            "name": "minlength",
-            "optional": true,
-            "integer": true,
-            "type": "Number",
-            "default-value": 5,
-            "disables-inputs": ["minlength_with_ACT", "act"],
-            "value-key": "[MINLENGTH_WITH_ACT]"
-        },
-        {
-=======
-            "value-key": "[MINLENGTH]"
-        },
-        {
->>>>>>> 4a34f65c4b251e80202c9063954376fc34e91b46
             "command-line-flag": "-maxlength",
             "description": "Set the maximum length of any track in mm (default is 100 x voxelsize).",
             "id": "maxlength",
@@ -135,38 +93,9 @@
             "optional": true,
             "type": "Number",
             "default-value": 0.05,
-<<<<<<< HEAD
-            "disables-inputs": ["cutoff_fixel", "cutoff_tensor"],
             "value-key": "[CUTOFF_FOD]"
         },
         {
-            "command-line-flag": "-cutoff",
-            "description": "Set the FOD amplitude / fixel size / tensor FA cutoff for terminating tracks (defaults are: 0.05 for FOD-based algorithms; 0.05 for fixel-based algorithms; 0.1 for tensor-based algorithms).",
-            "id": "cutoff_fixel",
-            "name": "Fixel cutoff",
-            "optional": true,
-            "type": "Number",
-            "default-value": 0.05,
-            "disables-inputs": ["cutoff_FOD", "cutoff_tensor"],
-            "value-key": "[CUTOFF_FIXEL]"
-        },
-        {
-            "command-line-flag": "-cutoff",
-            "description": "Set the FOD amplitude / fixel size / tensor FA cutoff for terminating tracks (defaults are: 0.05 for FOD-based algorithms; 0.05 for fixel-based algorithms; 0.1 for tensor-based algorithms).",
-            "id": "cutoff_tensor",
-            "name": "Tensor cutoff",
-            "optional": true,
-            "type": "Number",
-            "default-value": 0.1,
-            "disables-inputs": ["cutoff_fixel", "cutoff_FOD"],
-            "value-key": "[CUTOFF_TENSOR]"
-        },
-        {
-=======
-            "value-key": "[CUTOFF_FOD]"
-        },
-        {
->>>>>>> 4a34f65c4b251e80202c9063954376fc34e91b46
             "command-line-flag": "-trials",
             "description": "Set the maximum number of sampling trials at each point (only used for probabilistic tracking).",
             "id": "trials",
@@ -210,27 +139,9 @@
             "name": "downsample",
             "optional": true,
             "type": "Number",
-<<<<<<< HEAD
-            "disables-inputs": ["downsample_iFOD2"],
             "value-key": "[DOWNSAMPLE]"
         },
         {
-            "command-line-flag": "-downsample",
-            "description": "Downsample the generated streamlines to reduce output file size (default is (samples-1) for iFOD2)",
-            "id": "downsample_iFOD2",
-            "name": "downsample for iFOD2",
-            "optional": true,
-            "type": "Number",
-            "default-value": -1,
-            "disables-inputs": ["downsample"],
-            "value-key": "[DOWNSAMPLE_IFOD2]"
-        },
-        {
-=======
-            "value-key": "[DOWNSAMPLE]"
-        },
-        {
->>>>>>> 4a34f65c4b251e80202c9063954376fc34e91b46
             "command-line-flag": "-seed_image",
             "description": "Seed streamlines entirely at random within a mask image",
             "id": "seed_image",
@@ -392,91 +303,33 @@
             "name": "include binary mask region",
             "optional": true,
             "type": "File",
-<<<<<<< HEAD
-            "disables-inputs": ["include_sphere"],
             "value-key": "[INCLUDE_BIN_MASK]"
         },
         {
-            "command-line-flag": "-include",
-            "description": "Specify an inclusion region of interest, as a sphere using 4 comma-separared values (x,y,z,radius). Streamlines must traverse ALL inclusion regions to be accepted.",
-            "id": "include_sphere",
-            "name": "include sphere region",
-            "optional": true,
-            "list": true,
-            "type": "Number",
-            "disables-inputs": ["include_bin_mask"],
-            "value-key": "[INCLUDE_SPHERE]"
-        },
-        {
-=======
-            "value-key": "[INCLUDE_BIN_MASK]"
-        },
-        {
->>>>>>> 4a34f65c4b251e80202c9063954376fc34e91b46
             "command-line-flag": "-exclude",
             "description": "Specify an exclusion region of interest, as either a binary mask image. Streamlines that enter ANY exclude region will be discarded.",
             "id": "exclude_bin_mask",
             "name": "exclude binary mask region",
             "optional": true,
             "type": "File",
-<<<<<<< HEAD
-            "disables-inputs": ["exclude_sphere"],
             "value-key": "[EXCLUDE_BIN_MASK]"
         },
         {
-            "command-line-flag": "-exclude",
-            "description": "Specify an exclusion region of interest, as a sphere using 4 comma-separared values (x,y,z,radius). Streamlines that enter ANY exclude region will be discarded.",
-            "id": "exclude_sphere",
-            "name": "exclude sphere region",
-            "optional": true,
-            "list": true,
-            "type": "Number",
-            "disables-inputs": ["exclude_bin_mask"],
-            "value-key": "[EXCLUDE_SPHERE]"
-        },
-        {
-=======
-            "value-key": "[EXCLUDE_BIN_MASK]"
-        },
-        {
->>>>>>> 4a34f65c4b251e80202c9063954376fc34e91b46
             "command-line-flag": "-mask",
             "description": "Specify a masking region of interest, as either a binary mask image. If defined, streamlines exiting the mask will be truncated.",
             "id": "mask_bin_mask",
             "name": "mask binary mask region",
             "optional": true,
             "type": "File",
-<<<<<<< HEAD
-            "disables-inputs": ["mask_sphere"],
             "value-key": "[MASK_BIN_MASK]"
         },
         {
-            "command-line-flag": "-mask",
-            "description": "Specify a masking region of interest, as a sphere using 4 comma-separared values (x,y,z,radius). If defined, streamlines exiting the mask will be truncated.",
-            "id": "mask_sphere",
-            "name": "mask sphere region",
-            "optional": true,
-            "list": true,
-            "type": "Number",
-            "disables-inputs": ["mask_bin_mask"],
-            "value-key": "[MASK_SPHERE]"
-        },
-        {
-=======
-            "value-key": "[MASK_BIN_MASK]"
-        },
-        {
->>>>>>> 4a34f65c4b251e80202c9063954376fc34e91b46
             "command-line-flag": "-act",
             "description": "Use the Anatomically-Constrained Tractography framework during tracking; provided image must be in the 5TT (five-tissue-type) format",
             "id": "act",
             "name": "act",
             "optional": true,
             "type": "File",
-<<<<<<< HEAD
-            "disables-inputs": ["minlength"],
-=======
->>>>>>> 4a34f65c4b251e80202c9063954376fc34e91b46
             "value-key": "[ACT]"
         },
         {
@@ -690,8 +543,4 @@
         ]
     },
     "tool-version": "v0.1.0"
-<<<<<<< HEAD
 }
-=======
-}
->>>>>>> 4a34f65c4b251e80202c9063954376fc34e91b46

--- a/code/tractography/mrtrix/tckgen_desc.json
+++ b/code/tractography/mrtrix/tckgen_desc.json
@@ -607,11 +607,11 @@
             "name": "Tracks output",
             "description": "The output file containing the tracks generated.",
             "optional": false,
-            "path-template": "[TRACKS].trk",
+            "path-template": "[TRACKS].tck",
             "path-template-stripped-extensions": [
                 ".nii.gz",
                 ".nii",
-                ".json"
+                ".tck"
             ]
         },
         {
@@ -621,9 +621,7 @@
             "optional": true,
             "path-template": "[OUTPUT_SEEDS].txt",
             "path-template-stripped-extensions": [
-                ".nii.gz",
-                ".nii",
-                ".json"
+                ".txt"
             ]
         }
     ],

--- a/code/tractography/mrtrix/tckgen_desc.json
+++ b/code/tractography/mrtrix/tckgen_desc.json
@@ -1,0 +1,646 @@
+{
+    "author": "Darrin Fong",
+    "command-line": "tckgen [ALGORITHM] [SELECT] [STEP_DEFAULT] [STEP_IFOD2] [ANGLE] [MINLENGTH] [MINLENGTH_WITH_ACT] [MAXLENGTH] [CUTOFF_FOD] [CUTOFF_FIXEL] [CUTOFF_TENSOR] [TRIALS] [NOPRECOMPUTED] [RK4] [STOP] [DOWNSAMPLE] [DOWNSAMPLE_IFOD2] [SEED_IMAGE] [SEED_SPHERE] [SEED_RANDOM_PER_VOXEL] [NUM_PER_VOXEL] [SEED_GRID_PER_VOXEL] [GRID_SIZE] [SEED_REJECTION] [SEED_GMWMI] [SEED_DYNAMIC] [SEEDS] [MAX_ATTEMPTS_PER_SEED] [SEED_CUTOFF] [SEED_UNIDIRECTIONAL] [SEED_DIRECTION] [OUTPUT_SEEDS] [INCLUDE_BIN_MASK] [INCLUDE_SPHERE] [EXCLUDE_BIN_MASK] [EXCLUDE_SPHERE] [MASK_BIN_MASK] [MASK_SPHERE] [ACT] [BACKTRACK] [CROP_AT_GMWMI] [SAMPLES] [POWER] [GRAD] [FSLGRAD] [BVECS] [BVALS] [BVALUE_SCALING] [INFO] [QUIET] [DEBUG] [FORCE] [NTHREADS] [HELP] [VERSION] [SOURCE] [TRACKS]",
+    "container-image": {
+        "image": "darrinfong/mrtrix3:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "name": "tckgen Streamlines tractography",
+    "description": "Perform streamlines tractography.",
+    "inputs": [
+        {
+            "command-line-flag": "-algorithm",
+            "description": "Specify the tractography algorithm to use. Valid choices are: FACT, iFOD1, iFOD2, Nulldist1, Nulldist2, SD_Stream, Seedtest, Tensor_Det, Tensor_Prob (default: iFOD2).",
+            "id": "algorithm",
+            "name": "algorithm",
+            "optional": true,
+            "value-choices": ["FACT", "iFOD1", "iFOD2", "Nulldist1", "Nulldist2", "SD_Stream", "Seedtest", "Tensor_Det", "Tensor_Prob"],
+            "type": "String",
+            "default-value": "iFOD2",
+            "value-disables": {
+                "FACT": ["samples", "power", "step_iFOD2", "cutoff_FOD", "cutoff_tensor", "downsample_iFOD2"],
+                "iFOD1": ["samples", "power", "step_iFOD2", "cutoff_fixel", "cutoff_tensor", "downsample_iFOD2"],
+                "iFOD2": ["step_default", "cutoff_fixel", "cutoff_tensor", "downsample"],
+                "Nulldist1": ["samples", "power", "step_iFOD2", "cutoff_FOD", "cutoff_tensor", "downsample_iFOD2"],
+                "Nulldist2": ["samples", "power", "step_iFOD2", "cutoff_FOD", "cutoff_tensor", "downsample_iFOD2"],
+                "SD_Stream": ["samples", "power", "step_iFOD2", "cutoff_fixel", "cutoff_tensor", "downsample_iFOD2"],
+                "Seedtest": ["samples", "power", "step_iFOD2", "cutoff_FOD", "cutoff_tensor", "downsample_iFOD2"],
+                "Tensor_Det": ["samples", "power", "step_iFOD2", "cutoff_FOD", "cutoff_fixel", "downsample_iFOD2"],
+                "Tensor_Prob": ["samples", "power", "step_iFOD2", "cutoff_FOD", "cutoff_fixel", "downsample_iFOD2"]
+            },
+            "value-key": "[ALGORITHM]"
+        },
+        {
+            "command-line-flag": "-select",
+            "description": "Set the desired number of streamlines to be selected by tckgen, after all selection criteria have been applied (i.e. inclusion/exclusion ROIs, min/max length, etc). tckgen will keep seeding streamlines until this number of streamlines have been selected, or the maximum allowed number of seeds has been exceeded (see -seeds option). By default, 5000 streamlines are to be selected. Set to zero to disable, which will result in streamlines being seeded until the number specified by -seeds has been reached.",
+            "id": "select",
+            "name": "select",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "minimum": 0,
+            "default-value": 5000,
+            "value-key": "[SELECT]"
+        },
+        {
+            "command-line-flag": "-step",
+            "description": "Set the step size of the algorithm in mm (default is 0.1 x voxelsize).",
+            "id": "step_default",
+            "name": "Default step",
+            "optional": true,
+            "type": "Number",
+            "default-value": 0.1,
+            "disables-inputs": ["step_iFOD2"],
+            "value-key": "[STEP_DEFAULT]"
+        },
+        {
+            "command-line-flag": "-step",
+            "description": "Set the step size of the algorithm in mm (default for iFOD2: 0.5 x voxelsize).",
+            "id": "step_iFOD2",
+            "name": "iFOD2 step",
+            "optional": true,
+            "type": "Number",
+            "default-value": 0.5,
+            "disables-inputs": ["step_default"],
+            "value-key": "[STEP_IFOD2]"
+        },
+        {
+            "command-line-flag": "-angle",
+            "description": "Set the maximum angle between successive steps (default is 90deg x stepsize / voxelsize).",
+            "id": "angle",
+            "name": "angle",
+            "optional": true,
+            "type": "Number",
+            "default-value": 90,
+            "value-key": "[ANGLE]"
+        },
+        {
+            "command-line-flag": "-minlength",
+            "description": "Set the minimum length of any track in mm (default is 2 x voxelsize with ACT).",
+            "id": "minlength_with_ACT",
+            "name": "minlength with ACT",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "default-value": 2,
+            "disables-inputs": ["minlength"],
+            "requires-inputs": ["act"],
+            "value-key": "[MINLENGTH]"
+        },
+        {
+            "command-line-flag": "-minlength",
+            "description": "Set the minimum length of any track in mm (default is 5 x voxelsize without ACT).",
+            "id": "minlength",
+            "name": "minlength",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "default-value": 5,
+            "disables-inputs": ["minlength_with_ACT", "act"],
+            "value-key": "[MINLENGTH_WITH_ACT]"
+        },
+        {
+            "command-line-flag": "-maxlength",
+            "description": "Set the maximum length of any track in mm (default is 100 x voxelsize).",
+            "id": "maxlength",
+            "name": "maxlength",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "default-value": 100,
+            "value-key": "[MAXLENGTH]"
+        },
+        {
+            "command-line-flag": "-cutoff",
+            "description": "Set the FOD amplitude / fixel size / tensor FA cutoff for terminating tracks (defaults are: 0.05 for FOD-based algorithms; 0.05 for fixel-based algorithms; 0.1 for tensor-based algorithms).",
+            "id": "cutoff_FOD",
+            "name": "FOD cutoff",
+            "optional": true,
+            "type": "Number",
+            "default-value": 0.05,
+            "disables-inputs": ["cutoff_fixel", "cutoff_tensor"],
+            "value-key": "[CUTOFF_FOD]"
+        },
+        {
+            "command-line-flag": "-cutoff",
+            "description": "Set the FOD amplitude / fixel size / tensor FA cutoff for terminating tracks (defaults are: 0.05 for FOD-based algorithms; 0.05 for fixel-based algorithms; 0.1 for tensor-based algorithms).",
+            "id": "cutoff_fixel",
+            "name": "Fixel cutoff",
+            "optional": true,
+            "type": "Number",
+            "default-value": 0.05,
+            "disables-inputs": ["cutoff_FOD", "cutoff_tensor"],
+            "value-key": "[CUTOFF_FIXEL]"
+        },
+        {
+            "command-line-flag": "-cutoff",
+            "description": "Set the FOD amplitude / fixel size / tensor FA cutoff for terminating tracks (defaults are: 0.05 for FOD-based algorithms; 0.05 for fixel-based algorithms; 0.1 for tensor-based algorithms).",
+            "id": "cutoff_tensor",
+            "name": "Tensor cutoff",
+            "optional": true,
+            "type": "Number",
+            "default-value": 0.1,
+            "disables-inputs": ["cutoff_fixel", "cutoff_FOD"],
+            "value-key": "[CUTOFF_TENSOR]"
+        },
+        {
+            "command-line-flag": "-trials",
+            "description": "Set the maximum number of sampling trials at each point (only used for probabilistic tracking).",
+            "id": "trials",
+            "name": "trials",
+            "optional": true,
+            "integer":true,
+            "type": "Number",
+            "value-key": "[TRIALS]"
+        },
+        {
+            "command-line-flag": "-noprecomputed",
+            "description": "Do NOT pre-compute legendre polynomial values. Warning: this will slow down the algorithm by a factor of approximately 4.",
+            "id": "noprecomputed",
+            "name": "noprecomputed",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[NOPRECOMPUTED]"
+        },
+        {
+            "command-line-flag": "-rk4",
+            "description": "Use 4th-order Runge-Kutta integration (slower, but eliminates curvature overshoot in 1st-order deterministic methods)",
+            "id": "rk4",
+            "name": "rk4",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[RK4]"
+        },
+        {
+            "command-line-flag": "-stop",
+            "description": "Stop propagating a streamline once it has traversed all include regions",
+            "id": "stop",
+            "name": "stop",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[STOP]"
+        },
+        {
+            "command-line-flag": "-downsample",
+            "description": "Downsample the generated streamlines to reduce output file size (default is no downsampling, except iFOD2)",
+            "id": "downsample",
+            "name": "downsample",
+            "optional": true,
+            "type": "Number",
+            "disables-inputs": ["downsample_iFOD2"],
+            "value-key": "[DOWNSAMPLE]"
+        },
+        {
+            "command-line-flag": "-downsample",
+            "description": "Downsample the generated streamlines to reduce output file size (default is (samples-1) for iFOD2)",
+            "id": "downsample_iFOD2",
+            "name": "downsample for iFOD2",
+            "optional": true,
+            "type": "Number",
+            "default-value": -1,
+            "disables-inputs": ["downsample"],
+            "value-key": "[DOWNSAMPLE_IFOD2]"
+        },
+        {
+            "command-line-flag": "-seed_image",
+            "description": "Seed streamlines entirely at random within a mask image",
+            "id": "seed_image",
+            "name": "seed_image",
+            "optional": true,
+            "type": "File",
+            "disables-inputs": ["seed_dynamic"],
+            "value-key": "[SEED_IMAGE]"
+        },
+        {
+            "command-line-flag": "-seed_sphere",
+            "description": "Spherical seed as four comma-separated values (XYZ position and radius)",
+            "id": "seed_sphere",
+            "name": "seed_sphere",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "disables-inputs": ["seed_dynamic"],
+            "value-key": "[SEED_SPHERE]"
+        },
+        {
+            "command-line-flag": "-seed_random_per_voxel",
+            "description": "Seed a fixed number of streamlines per voxel in a mask image; random placement of seeds in each voxel",
+            "id": "seed_random_per_voxel",
+            "name": "seed_random_per_voxel",
+            "optional": true,
+            "type": "File",
+            "requires-inputs": ["num_per_voxel"],
+            "disables-inputs": ["seed_dynamic"],
+            "value-key": "[SEED_RANDOM_PER_VOXEL]"
+        },
+        {
+            "description": "Seed a fixed number of streamlines per voxel in a mask image; random placement of seeds in each voxel",
+            "id": "num_per_voxel",
+            "name": "Streamlines number per voxel",
+            "optional": true,
+            "type": "Number",
+            "requires-inputs": ["seed_random_per_voxel"],
+            "disables-inputs": ["seed_dynamic"],
+            "value-key": "[NUM_PER_VOXEL]"
+        },
+        {
+            "command-line-flag": "-seed_grid_per_voxel",
+            "description": "Seed a fixed number of streamlines per voxel in a mask image; place seeds on a 3D mesh grid (grid_size argument is per axis; so a grid_size of 3 results in 27 seeds per voxel)",
+            "id": "seed_grid_per_voxel",
+            "name": "seed_grid_per_voxel",
+            "optional": true,
+            "type": "File",
+            "requires-inputs": ["grid_size"],
+            "disables-inputs": ["seed_dynamic"],
+            "value-key": "[SEED_GRID_PER_VOXEL]"
+        },
+        {
+            "description": "Seed a fixed number of streamlines per voxel in a mask image; place seeds on a 3D mesh grid (grid_size argument is per axis; so a grid_size of 3 results in 27 seeds per voxel)",
+            "id": "grid_size",
+            "name": "3D Seeds mesh grid",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "requires-inputs": ["seed_grid_per_voxel"],
+            "disables-inputs": ["seed_dynamic"],
+            "value-key": "[GRID_SIZE]"
+        },
+        {
+            "command-line-flag": "-seed_rejection",
+            "description": "Seed from an image using rejection sampling (higher values = more probable to seed from)",
+            "id": "seed_rejection",
+            "name": "seed_rejection",
+            "optional": true,
+            "type": "File",
+            "disables-inputs": ["seed_dynamic"],
+            "value-key": "[SEED_REJECTION]"
+        },
+        {
+            "command-line-flag": "-seed_gmwmi",
+            "description": "Seed from the grey matter - white matter interface (only valid if using ACT framework). Input image should be a 3D seeding volume; seeds drawn within this image will be optimised to the interface using the 5TT image provided using the -act option.",
+            "id": "seed_gmwmi",
+            "name": "seed_gmwmi",
+            "optional": true,
+            "type": "File",
+            "requires-inputs": ["act"],
+            "disables-inputs": ["seed_dynamic"],
+            "value-key": "[SEED_GMWMI]"
+        },
+        {
+            "command-line-flag": "-seed_dynamic",
+            "description": "Ddetermine seed points dynamically using the SIFT model (must not provide any other seeding mechanism). Note that while this seeding mechanism improves the distribution of reconstructed streamlines density, it should NOT be used as a substitute for the SIFT method itself.",
+            "id": "seed_dynamic",
+            "name": "seed_dynamic",
+            "optional": true,
+            "type": "File",
+            "disables-inputs": ["seed_sphere", "seed_image", "seed_random_per_voxel", "seed_grid_per_voxel", "seed_rejection", "seed_gmwmi"],
+            "value-key": "[SEED_DYNAMIC]"
+        },
+        {
+            "command-line-flag": "-seeds",
+            "description": "Set the number of seeds that tckgen will attempt to track from. If this option is NOT provided, the default number of seeds is set to 1000× the number of selected streamlines. If -select is NOT also specified, tckgen will continue tracking until this number of seeds has been attempted. However, if -select is also specified, tckgen will stop when the number of seeds attempted reaches the number specified here, OR when the number of streamlines selected reaches the number requested with the -select option. This can be used to prevent the program from running indefinitely when no or very few streamlines can be found that match the selection criteria. Setting this to zero will cause tckgen to keep attempting seeds until the number specified by -select has been reached.",
+            "id": "seeds",
+            "name": "seeds",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "minimum": 0,
+            "value-key": "[SEEDS]"
+        },
+        {
+            "command-line-flag": "-max_attempts_per_seed",
+            "description": "Set the maximum number of times that the tracking algorithm should attempt to find an appropriate tracking direction from a given seed point. This should be set high enough to ensure that an actual plausible seed point is not discarded prematurely as being unable to initiate tracking from. Higher settings may affect performance if many seeds are genuinely impossible to track from, as many attempts will still be made in vain for such seeds. (default: 1000)",
+            "id": "max_attempts_per_seed",
+            "name": "Maximum attempts per seed",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "default-value": 1000,
+            "value-key": "[MAX_ATTEMPTS_PER_SEED]"
+        },
+        {
+            "command-line-flag": "-seed_cutoff",
+            "description": "Set the minimum FA or FOD amplitude for seeding tracks (default is the same as the normal -cutoff).",
+            "id": "seed_cutoff",
+            "name": "Seed cutoff",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[SEED_CUTOFF]"
+        },
+        {
+            "command-line-flag": "-seed_unidirectional",
+            "description": "Track from the seed point in one direction only (default is to track in both directions).",
+            "id": "seed_unidirectional",
+            "name": "Seed unidirectionally",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[SEED_UNIDIRECTIONAL]"
+        },
+        {
+            "command-line-flag": "-seed_direction",
+            "description": "Specify a seeding direction for the tracking (this should be supplied as a vector of 3 comma-separated values.",
+            "id": "seed_direction",
+            "name": "Seed direction",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "value-key": "[SEED_DIRECTION]"
+        },
+        {
+            "command-line-flag": "-output_seeds",
+            "description": "Output the seed location of all successful streamlines to a file",
+            "id": "output_seeds",
+            "name": "output_seeds",
+            "optional": true,
+            "type": "String",
+            "value-key": "[OUTPUT_SEEDS]"
+        },
+        {
+            "command-line-flag": "-include",
+            "description": "Specify an inclusion region of interest, as either a binary mask image. Streamlines must traverse ALL inclusion regions to be accepted.",
+            "id": "include_bin_mask",
+            "name": "include binary mask region",
+            "optional": true,
+            "type": "File",
+            "disables-inputs": ["include_sphere"],
+            "value-key": "[INCLUDE_BIN_MASK]"
+        },
+        {
+            "command-line-flag": "-include",
+            "description": "Specify an inclusion region of interest, as a sphere using 4 comma-separared values (x,y,z,radius). Streamlines must traverse ALL inclusion regions to be accepted.",
+            "id": "include_sphere",
+            "name": "include sphere region",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "disables-inputs": ["include_bin_mask"],
+            "value-key": "[INCLUDE_SPHERE]"
+        },
+        {
+            "command-line-flag": "-exclude",
+            "description": "Specify an exclusion region of interest, as either a binary mask image. Streamlines that enter ANY exclude region will be discarded.",
+            "id": "exclude_bin_mask",
+            "name": "exclude binary mask region",
+            "optional": true,
+            "type": "File",
+            "disables-inputs": ["exclude_sphere"],
+            "value-key": "[EXCLUDE_BIN_MASK]"
+        },
+        {
+            "command-line-flag": "-exclude",
+            "description": "Specify an exclusion region of interest, as a sphere using 4 comma-separared values (x,y,z,radius). Streamlines that enter ANY exclude region will be discarded.",
+            "id": "exclude_sphere",
+            "name": "exclude sphere region",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "disables-inputs": ["exclude_bin_mask"],
+            "value-key": "[EXCLUDE_SPHERE]"
+        },
+        {
+            "command-line-flag": "-mask",
+            "description": "Specify a masking region of interest, as either a binary mask image. If defined, streamlines exiting the mask will be truncated.",
+            "id": "mask_bin_mask",
+            "name": "mask binary mask region",
+            "optional": true,
+            "type": "File",
+            "disables-inputs": ["mask_sphere"],
+            "value-key": "[MASK_BIN_MASK]"
+        },
+        {
+            "command-line-flag": "-mask",
+            "description": "Specify a masking region of interest, as a sphere using 4 comma-separared values (x,y,z,radius). If defined, streamlines exiting the mask will be truncated.",
+            "id": "mask_sphere",
+            "name": "mask sphere region",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "disables-inputs": ["mask_bin_mask"],
+            "value-key": "[MASK_SPHERE]"
+        },
+        {
+            "command-line-flag": "-act",
+            "description": "Use the Anatomically-Constrained Tractography framework during tracking; provided image must be in the 5TT (five-tissue-type) format",
+            "id": "act",
+            "name": "act",
+            "optional": true,
+            "type": "File",
+            "disables-inputs": ["minlength"],
+            "value-key": "[ACT]"
+        },
+        {
+            "command-line-flag": "-backtrack",
+            "description": "Allow tracks to be truncated and re-tracked if a poor structural termination is encountered",
+            "id": "backtrack",
+            "name": "backtrack",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[BACKTRACK]"
+        },
+        {
+            "command-line-flag": "-crop_at_gmwmi",
+            "description": "Crop streamline endpoints more precisely as they cross the GM-WM interface",
+            "id": "crop_at_gmwmi",
+            "name": "crop_at_gmwmi",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[CROP_AT_GMWMI]"
+        },
+        {
+            "command-line-flag": "-samples",
+            "description": "Set the number of FOD samples to take per step (Default: 4)",
+            "id": "samples",
+            "name": "samples",
+            "optional": true,
+            "integer":true,
+            "type": "Number",
+            "default-value": 4,
+            "value-key": "[SAMPLES]"
+        },
+        {
+            "command-line-flag": "-power",
+            "description": "Raise the FOD to the power specified (default is 1/nsamples).",
+            "id": "power",
+            "name": "power",
+            "optional": true,
+            "type": "Number",
+            "default-value": 1,
+            "value-key": "[POWER]"
+        },
+        {
+            "command-line-flag": "-grad",
+            "description": "Provide the diffusion-weighted gradient scheme used in the acquisition in a text file. This should be supplied as a 4xN text file with each line is in the format [ X Y Z b ], where [ X Y Z ] describe the direction of the applied gradient, and b gives the b-value in units of s/mm^2. If a diffusion gradient scheme is present in the input image header, the data provided with this option will be instead used.",
+            "id": "grad",
+            "name": "grad",
+            "optional": true,
+            "type": "File",
+            "value-key": "[GRAD]"
+        },
+        {
+            "command-line-flag": "-fslgrad",
+            "description": "Provide the diffusion-weighted gradient scheme used in the acquisition in FSL bvecs/bvals format files. If a diffusion gradient scheme is present in the input image header, the data provided with this option will be instead used.",
+            "id": "fslgrad",
+            "name": "fslgrad",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FSLGRAD]",
+            "requires-inputs": ["bvecs", "bvals"]
+        },
+        {
+            "description": "Specify the diffusion-weighted gradient scheme used in the acquisition in FSL bvecs format.",
+            "id": "bvecs",
+            "name": "bvecs",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVECS]",
+            "requires-inputs": ["fslgrad", "bvals"]
+        },
+        {
+            "description": "Specify the diffusion-weighted gradient scheme used in the acquisition in FSL bvals format.",
+            "id": "bvals",
+            "name": "bvals",
+            "optional": true,
+            "type": "File",
+            "value-key": "[BVALS]",
+            "requires-inputs": ["fslgrad", "bvecs"]
+        },
+        {
+            "command-line-flag": "-bvalue_scaling",
+            "description": "Specifies whether the b-values should be scaled by the square of the corresponding DW gradient norm, as often required for multi-shell or DSI DW acquisition schemes. The default action can also be set in the MRtrix config file, under the BValueScaling entry. Valid choices are yes/no, true/false, 0/1 (default: true).",
+            "id": "bvalue_scaling",
+            "name": "bvalue_scaling",
+            "optional": true,
+            "type": "String",
+            "value-key": "[BVALUE_SCALING]",
+            "value-choices": ["yes", "no", "true", "false", "0", "1"],
+            "default-value": "true"
+        },
+        {
+            "command-line-flag": "-info",
+            "description": "Display information messages.",
+            "id": "info",
+            "name": "info",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[INFO]",
+            "disables-inputs": ["quiet", "debug"]
+        },
+        {
+            "command-line-flag": "-quiet",
+            "description": "Do not display information messages or progress status.",
+            "id": "quiet",
+            "name": "quiet",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[QUIET]",
+            "disables-inputs": ["info", "debug"]
+        },
+        {
+            "command-line-flag": "-debug",
+            "description": "Display debugging messages.",
+            "id": "debug",
+            "name": "debug",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DEBUG]",
+            "disables-inputs": ["info", "quiet"]
+        },
+        {
+            "command-line-flag": "-force",
+            "description": "Force overwrite of output files. Caution: Using the same file as input and output might cause unexpected behaviour.",
+            "id": "force",
+            "name": "force",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FORCE]"
+        },
+        {
+            "command-line-flag": "-nthreads",
+            "description": "Use this number of threads in multi-threaded applications (set to 0 to disable multi-threading)",
+            "id": "nthreads",
+            "name": "nthreads",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[NTHREADS]"
+        },
+        {
+            "command-line-flag": "-help",
+            "description": "Display this information page and exit",
+            "id": "help",
+            "name": "help",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HELP]"
+        },
+        {
+            "command-line-flag": "-version",
+            "description": "Display version information and exit",
+            "id": "version",
+            "name": "version",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[VERSION]"
+        },
+        {
+            "description": "The image containing the source data. The type of image data required depends on the algorithm used (see Description section).",
+            "id": "source",
+            "name": "source",
+            "optional": false,
+            "type": "File",
+            "value-key": "[SOURCE]"
+        },
+        {
+            "description": "The output file containing the tracks generated.",
+            "id": "tracks",
+            "name": "Tracks generated",
+            "optional": false,
+            "type": "String",
+            "value-key": "[TRACKS]"
+        }
+    ],
+    "output-files": [
+        {
+            "id": "tracks_output",
+            "name": "Tracks output",
+            "description": "The output file containing the tracks generated.",
+            "optional": false,
+            "path-template": "[TRACKS].trk",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii",
+                ".json"
+            ]
+        },
+        {
+            "id": "Seed_location",
+            "name": "Seed location",
+            "description": "Seed location of all successful streamlines",
+            "optional": true,
+            "path-template": "[OUTPUT_SEEDS].txt",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii",
+                ".json"
+            ]
+        }
+    ],
+    "schema-version": "0.5",
+    "suggested-resources": {
+        "cpu-cores": 1,
+        "ram": 2048,
+        "walltime-estimate": 20
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "image processing",
+            "mri",
+            "dwi",
+            "tractography"
+        ]
+    },
+    "tool-version": "v0.1.0"
+}

--- a/code/tractography/mrtrix/tckmap_desc.json
+++ b/code/tractography/mrtrix/tckmap_desc.json
@@ -1,0 +1,320 @@
+{
+    "author": "Darrin Fong",
+    "command-line": "dwi2mask [TEMPLATE] [VOX_SIZE] [VOX_DIMENSIONS] [DATATYPE] [DEC] [DIXELS] [DIXEL_DIRECTIONS] [TOD] [CONTRAST] [IMAGE] [VECTOR_FILE] [STAT_VOX] [STAT_TCK] [FWHM_TCK] [MAP_ZERO] [BACKTRACK] [UPSAMPLE] [PRECISE] [ENDS_ONLY] [TCK_WEIGHTS_IN] [INFO] [QUIET] [DEBUG] [FORCE] [NTHREADS] [HELP] [VERSION] [TRACKS] [OUTPUT]",
+    "container-image": {
+        "image": "darrinfong/mrtrix3:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "name": "dwi2mask Brain mask generator",
+    "description": "Generates an whole brain mask from a DWI image.All diffusion weighted and b=0 volumes are used to obtain a mask that includes both brain tissue and CSF",
+    "inputs": [
+        {
+            "command-line-flag": "-template",
+            "description": "An image file to be used as a template for the output (the output image will have the same transform and field of view).",
+            "id": "template",
+            "name": "template",
+            "optional": true,
+            "type": "File",
+            "value-key": "[TEMPLATE]"
+        },
+        {
+            "command-line-flag": "-vox",
+            "description": "Provide an isotropic voxel size (in mm).",
+            "id": "vox_size",
+            "name": "vox size",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "disables-inputs": ["vox_dimensions"],
+            "value-key": "[VOX_SIZE]"
+        },
+        {
+            "command-line-flag": "-vox",
+            "description": "Provide a comma-separated list of 3 voxel dimensions.",
+            "id": "vox_dimensions",
+            "name": "vox dimensions",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "disables-inputs": ["vox_size"],
+            "value-key": "[VOX_DIMENSIONS]"
+        },
+        {
+            "command-line-flag": "-datatype",
+            "description": "Specify output image data type.",
+            "id": "datatype",
+            "name": "datatype",
+            "optional": true,
+            "type": "String",
+            "value-key": "[DATATYPE]"
+        },
+        {
+            "command-line-flag": "-dec",
+            "description": "Perform track mapping in directionally-encoded colour (DEC) space",
+            "id": "dec",
+            "name": "dec",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DEC]"
+        },
+        {
+            "command-line-flag": "-dixel",
+            "description": "Map streamlines to dixels within each voxel; requires a number of dixels (references an internal direction set).",
+            "id": "dixels",
+            "name": "A number of dixels",
+            "optional": true,
+            "list": true,
+            "type": "Number",
+            "disables-inputs": ["dixel_directions"],
+            "value-key": "[DIXELS]"
+        },
+        {
+            "command-line-flag": "-dixel",
+            "description": "Map streamlines to dixels within each voxel; requires a path to a text file containing a set of directions stored as aximuth/elevation pairs",
+            "id": "dixel_directions",
+            "name": "dixel directions file",
+            "optional": true,
+            "type": "File",
+            "disables-inputs": ["dixels"],
+            "value-key": "[DIXEL_DIRECTIONS]"
+        },
+        {
+            "command-line-flag": "-tod",
+            "description": "Generate a Track Orientation Distribution (TOD) in each voxel; need to specify the maximum spherical harmonic degree lmax to use when generating Apodised Point Spread Functions",
+            "id": "tod",
+            "name": "tod",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[TOD]"
+        },
+        {
+            "command-line-flag": "-contrast",
+            "description": "Define the desired form of contrast for the output image Options are: tdi, length, invlength, scalar_map, scalar_map_count, fod_amp, curvature (default: tdi)",
+            "id": "contrast",
+            "name": "contrast",
+            "optional": true,
+            "type": "String",
+            "value-choices": ["tdi", "length", "invlength", "scalar_map", "scalar_map_count", "fod_amp", "curvature"],
+            "default-value": "tdi",
+            "value-key": "[CONTRAST]"
+        },
+        {
+            "command-line-flag": "-image",
+            "description": "Provide the scalar image map for generating images with 'scalar_map' / 'scalar_map_count' contrast, or the spherical harmonics image for 'fod_amp' contrast",
+            "id": "image",
+            "name": "image",
+            "optional": true,
+            "type": "File",
+            "value-key": "[IMAGE]"
+        },
+        {
+            "command-line-flag": "-vector_file",
+            "description": "Provide the vector data file for generating images with 'vector_file' contrast",
+            "id": "vector_file",
+            "name": "vector file",
+            "optional": true,
+            "type": "File",
+            "value-key": "[VECTOR_FILE]"
+        },
+        {
+            "command-line-flag": "-stat_vox",
+            "description": "Define the statistic for choosing the final voxel intensities for a given contrast type given the individual values from the tracks passing through each voxel Options are: sum, min, mean, max (default: sum)",
+            "id": "stat_vox",
+            "name": "stat_vox",
+            "optional": true,
+            "type": "String",
+            "value-choices": ["sum", "min", "mean", "max"],
+            "default-value": "sum",
+            "value-key": "[STAT_VOX]"
+        },
+        {
+            "command-line-flag": "-stat_tck",
+            "description": "Define the statistic for choosing the contribution to be made by each streamline as a function of the samples taken along their lengths Only has an effect for 'scalar_map', 'fod_amp' and 'curvature' contrast types Options are: sum, min, mean, max, median, mean_nonzero, gaussian, ends_min, ends_mean, ends_max, ends_prod (default: mean)",
+            "id": "stat_tck",
+            "name": "stat_tck",
+            "optional": true,
+            "type": "String",
+            "value-choices": ["sum", "min", "mean", "max", "median", "mean_nonzero", "gaussian", "ends_min", "ends_mean", "ends_max", "ends_prod"],
+            "default-value": "mean",
+            "value-key": "[STAT_TCK]"
+        },
+        {
+            "command-line-flag": "-fwhm_tck",
+            "description": "When using gaussian-smoothed per-track statistic, specify the desired full-width half-maximum of the Gaussian smoothing kernel (in mm)",
+            "id": "fwhm_tck",
+            "name": "fwhm_tck",
+            "optional": true,
+            "integer":true,
+            "type": "Number",
+            "value-key": "[FWHM_TCK]"
+        },
+        {
+            "command-line-flag": "-map_zero",
+            "description": "If a streamline has zero contribution based on the contrast & statistic, typically it is not mapped; use this option to still contribute to the map even if this is the case (these non-contributing voxels can then influence the mean value in each voxel of the map)",
+            "id": "map_zero",
+            "name": "map_zero",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[MAP_ZERO]"
+        },
+        {
+            "command-line-flag": "-backtrack",
+            "description": "When using -stat_tck ends_*, if the streamline endpoint is outside the FoV, backtrack along the streamline trajectory until an appropriate point is found",
+            "id": "backtrack",
+            "name": "backtrack",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[BACKTRACK]"
+        },
+        {
+            "command-line-flag": "-upsample",
+            "description": "Upsample the tracks by some ratio using Hermite interpolation before mappping (If omitted, an appropriate ratio will be determined automatically)",
+            "id": "upsample",
+            "name": "upsample",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[UPSAMPLE]"
+        },
+        {
+            "command-line-flag": "-precise",
+            "description": "Use a more precise streamline mapping strategy, that accurately quantifies the length through each voxel (these lengths are then taken into account during TWI calculation)",
+            "id": "precise",
+            "name": "precise",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[PRECISE]"
+        },
+        {
+            "command-line-flag": "-ends_only",
+            "description": "Only map the streamline endpoints to the image",
+            "id": "ends_only",
+            "name": "ends_only",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[ENDS_ONLY]"
+        },
+        {
+            "command-line-flag": "-tck_weights_in",
+            "description": "Specify a text scalar file containing the streamline weights",
+            "id": "tck_weights_in",
+            "name": "tck_weights_in",
+            "optional": true,
+            "type": "File",
+            "value-key": "[TCK_WEIGHTS_IN]"
+        },
+        {
+            "command-line-flag": "-info",
+            "description": "Display information messages.",
+            "id": "info",
+            "name": "info",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[INFO]",
+            "disables-inputs": ["quiet", "debug"]
+        },
+        {
+            "command-line-flag": "-quiet",
+            "description": "Do not display information messages or progress status. Alternatively, this can be achieved by setting the MRTRIX_QUIET environment variable to a non-empty string.",
+            "id": "quiet",
+            "name": "quiet",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[QUIET]",
+            "disables-inputs": ["info", "debug"]
+        },
+        {
+            "command-line-flag": "-debug",
+            "description": "Display debugging messages.",
+            "id": "debug",
+            "name": "debug",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DEBUG]",
+            "disables-inputs": ["info", "quiet"]
+        },
+        {
+            "command-line-flag": "-force",
+            "description": "Force overwrite of output files. Caution: Using the same file as input and output might cause unexpected behaviour.",
+            "id": "force",
+            "name": "force",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FORCE]"
+        },
+        {
+            "command-line-flag": "-nthreads",
+            "description": "Use this number of threads in multi-threaded applications (set to 0 to disable multi-threading)",
+            "id": "nthreads",
+            "name": "nthreads",
+            "optional": true,
+            "integer": true,
+            "type": "Number",
+            "value-key": "[NTHREADS]"
+        },
+        {
+            "command-line-flag": "-help",
+            "description": "Display this information page and exit",
+            "id": "help",
+            "name": "help",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HELP]"
+        },
+        {
+            "command-line-flag": "-version",
+            "description": "Display version information and exit",
+            "id": "version",
+            "name": "version",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[VERSION]"
+        },
+        {
+            "description": "The input track file",
+            "id": "tracks",
+            "name": "tracks",
+            "optional": false,
+            "type": "File",
+            "value-key": "[TRACKS]"
+        },
+        {
+            "description": "The output track-weighted image",
+            "id": "output",
+            "name": "output",
+            "optional": false,
+            "type": "String",
+            "value-key": "[OUTPUT]"
+        }
+    ],
+    "output-files": [
+        {
+            "id": "track_weighted_image",
+            "name": "Output track-weighted image",
+            "description": "The output track-weighted image",
+            "optional": false,
+            "path-template": "[OUTPUT].dwi",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii",
+                ".json"
+            ]
+        }
+    ],
+    "schema-version": "0.5",
+    "suggested-resources": {
+        "cpu-cores": 1,
+        "ram": 2048,
+        "walltime-estimate": 20
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "image processing",
+            "mri",
+            "dwi",
+            "tractography"
+        ]
+    },
+    "tool-version": "v0.1.0"
+}

--- a/code/tractography/mrtrix/tckmap_desc.json
+++ b/code/tractography/mrtrix/tckmap_desc.json
@@ -1,13 +1,13 @@
 {
     "author": "Darrin Fong",
-    "command-line": "dwi2mask [TEMPLATE] [VOX_SIZE] [VOX_DIMENSIONS] [DATATYPE] [DEC] [DIXELS] [DIXEL_DIRECTIONS] [TOD] [CONTRAST] [IMAGE] [VECTOR_FILE] [STAT_VOX] [STAT_TCK] [FWHM_TCK] [MAP_ZERO] [BACKTRACK] [UPSAMPLE] [PRECISE] [ENDS_ONLY] [TCK_WEIGHTS_IN] [INFO] [QUIET] [DEBUG] [FORCE] [NTHREADS] [HELP] [VERSION] [TRACKS] [OUTPUT]",
+    "command-line": "tckmap [TEMPLATE] [VOX_SIZE] [VOX_DIMENSIONS] [DATATYPE] [DEC] [DIXELS] [DIXEL_DIRECTIONS] [TOD] [CONTRAST] [IMAGE] [VECTOR_FILE] [STAT_VOX] [STAT_TCK] [FWHM_TCK] [MAP_ZERO] [BACKTRACK] [UPSAMPLE] [PRECISE] [ENDS_ONLY] [TCK_WEIGHTS_IN] [INFO] [QUIET] [DEBUG] [FORCE] [NTHREADS] [HELP] [VERSION] [TRACKS] [OUTPUT]",
     "container-image": {
         "image": "darrinfong/mrtrix3:latest",
         "index": "index.docker.io",
         "type": "docker"
     },
-    "name": "dwi2mask Brain mask generator",
-    "description": "Generates an whole brain mask from a DWI image.All diffusion weighted and b=0 volumes are used to obtain a mask that includes both brain tissue and CSF",
+    "name": "tckmap",
+    "description": "Use track data as a form of contrast for producing a high-resolution image.",
     "inputs": [
         {
             "command-line-flag": "-template",
@@ -293,11 +293,11 @@
             "name": "Output track-weighted image",
             "description": "The output track-weighted image",
             "optional": false,
-            "path-template": "[OUTPUT].dwi",
+            "path-template": "[OUTPUT].mif",
             "path-template-stripped-extensions": [
                 ".nii.gz",
                 ".nii",
-                ".json"
+                ".mif"
             ]
         }
     ],


### PR DESCRIPTION
Added mrtrix3 tools' descriptors to tractography/mrtrix:

dwi2fod
dwi2mask
dwi2response (split by algorithm due to algorithm specific options: fa, hollander, manual, msmt_5tt, tax, tournier)
tckedit
tckgen (complex, can potentially split by algorithm categories: FOD, Fixel, Tensor)
tckmap
All descriptors were validated using bosh validate.

>P.S.: bids/mrtrix3_connectome:latest container is compatible with the descriptors but is ~18.5GB compared to the ~1.85GB of darrinfong/mrtrix3:latest.